### PR TITLE
DDCE-1016: removed deprecated SessionKey attributes

### DIFF
--- a/test/builders/SessionBuilder.scala
+++ b/test/builders/SessionBuilder.scala
@@ -24,17 +24,14 @@ import uk.gov.hmrc.http.SessionKeys
 
 object SessionBuilder {
 
-  val TOKEN = "token"
-
   def updateRequestWithSession(
-    fakeRequest: FakeRequest[AnyContentAsJson],
-    userId: String): FakeRequest[AnyContentAsJson] = {
+    fakeRequest: FakeRequest[AnyContentAsJson]): FakeRequest[AnyContentAsJson] = {
     val sessionId = s"session-${UUID.randomUUID}"
-    fakeRequest.withSession(SessionKeys.sessionId -> sessionId, TOKEN -> "RANDOMTOKEN", SessionKeys.userId -> userId)
+    fakeRequest.withSession(SessionKeys.sessionId -> sessionId)
   }
 
-  def buildRequestWithSession(userId: String) = {
+  def buildRequestWithSession() = {
     val sessionId = s"session-${UUID.randomUUID}"
-    FakeRequest().withSession(SessionKeys.sessionId -> sessionId, TOKEN -> "RANDOMTOKEN", SessionKeys.userId -> userId)
+    FakeRequest().withSession(SessionKeys.sessionId -> sessionId)
   }
 }

--- a/test/controllers/FakePBIKApplication.scala
+++ b/test/controllers/FakePBIKApplication.scala
@@ -47,25 +47,15 @@ trait FakePBIKApplication extends OneAppPerSuite {
   )
 
   val sessionId = s"session-${UUID.randomUUID}"
-  val userId = s"user-${UUID.randomUUID}"
 
   def mockrequest: FakeRequest[AnyContentAsEmpty.type] =
-    FakeRequest().withSession(
-      SessionKeys.sessionId -> sessionId,
-      SessionKeys.token     -> "RANDOMTOKEN",
-      SessionKeys.userId    -> userId,
-      HeaderTags.ETAG       -> "0",
-      HeaderTags.X_TXID     -> "0")
+    FakeRequest().withSession(SessionKeys.sessionId -> sessionId, HeaderTags.ETAG -> "0", HeaderTags.X_TXID -> "0")
 
   def mockWelshrequest: FakeRequest[AnyContentAsEmpty.type] =
-    FakeRequest("GET", "?lang=cy").withSession(
-      SessionKeys.sessionId -> sessionId,
-      SessionKeys.token     -> "RANDOMTOKEN",
-      SessionKeys.userId    -> userId,
-      HeaderTags.ETAG       -> "0",
-      HeaderTags.X_TXID     -> "0")
+    FakeRequest("GET", "?lang=cy")
+      .withSession(SessionKeys.sessionId -> sessionId, HeaderTags.ETAG -> "0", HeaderTags.X_TXID -> "0")
 
-  def noSessionIdRequest: FakeRequest[AnyContentAsEmpty.type] = FakeRequest().withSession(SessionKeys.userId -> userId)
+  def noSessionIdRequest: FakeRequest[AnyContentAsEmpty.type] = FakeRequest().withSession()
 
   override lazy val fakeApplication: Application = GuiceApplicationBuilder(
     disabled = Seq(classOf[com.kenshoo.play.metrics.PlayModule])

--- a/test/controllers/HomePageControllerSpec.scala
+++ b/test/controllers/HomePageControllerSpec.scala
@@ -86,10 +86,8 @@ class HomePageControllerSpec extends PlaySpec with FakePBIKApplication with Test
   "HomePageController" should {
     "show Unauthorised if the session is not authenticated" in {
       val homePageController = app.injector.instanceOf[HomePageController]
-      implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest().withSession(
-        SessionKeys.sessionId -> "hackmeister",
-        SessionKeys.token     -> "RANDOMTOKEN",
-        SessionKeys.userId    -> userId)
+      implicit val request: FakeRequest[AnyContentAsEmpty.type] =
+        FakeRequest().withSession(SessionKeys.sessionId -> "hackmeister")
       val result = homePageController.onPageLoad.apply(request)
       status(result) must be(UNAUTHORIZED) //401
     }
@@ -135,10 +133,8 @@ class HomePageControllerSpec extends PlaySpec with FakePBIKApplication with Test
   "HomePageController" should {
     "display the navigation page" in {
       val homePageController = app.injector.instanceOf[HomePageController]
-      implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest().withSession(
-        SessionKeys.sessionId -> sessionId,
-        SessionKeys.token     -> "RANDOMTOKEN",
-        SessionKeys.userId    -> userId)
+      implicit val request: FakeRequest[AnyContentAsEmpty.type] =
+        FakeRequest().withSession(SessionKeys.sessionId -> sessionId)
       implicit val timeout: akka.util.Timeout = timeoutValue
       val result = await(homePageController.onPageLoad(request))(timeout)
       result.header.status must be(OK)

--- a/test/controllers/LanguageSupportSpec.scala
+++ b/test/controllers/LanguageSupportSpec.scala
@@ -80,10 +80,7 @@ class LanguageSupportSpec extends PlaySpec with TestAuthUser with FakePBIKApplic
     "display the navigation page" in {
       val homePageController = app.injector.instanceOf[HomePageController]
       implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest()
-        .withSession(
-          SessionKeys.sessionId -> sessionId,
-          SessionKeys.token     -> "RANDOMTOKEN",
-          SessionKeys.userId    -> userId)
+        .withSession(SessionKeys.sessionId -> sessionId)
         .withCookies(Cookie("PLAY_LANG", "cy"))
 
       implicit val timeout: FiniteDuration = timeoutValue


### PR DESCRIPTION
# DDCE-1016

Removed the session keys attributes that are being deprecated, only found references in the unit tests, checked the Acceptance tests and performance tests but couldn’t find any reference.
 
## PR Suggestions
- Have you looked at the JIRA story to make sure all Acceptance Criteria has been met?
- Have you done a visual check of the changes?
- Is there any still commented or unused code? Lingering printlns?
- Have things been implemented in a complicated way?
- Are the test still over the coverage threshold?
- Does the compiler throw a lot of warnings? 
- Have methods and tests been named clearly?
- Were there any changes in the config? Do changes need to be made in app-config-???
- Have you done a manual walkthrough?


## Checklist PR Raiser
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [x]  I've squashed my commits - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date
 
## Checklist PR Reviewer
 - [x]  I've verified every effort was made to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've verified appropriate tests were included with any code added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [x]  I've verified commits were squashed and rebased - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
