### PR TITLE
DDCE-3460 : Accessibility Fix - Headers and radio options

### DIFF
--- a/app/controllers/ExclusionListController.scala
+++ b/app/controllers/ExclusionListController.scala
@@ -240,8 +240,8 @@ class ExclusionListController @Inject() (
 
   def showExclusionSearchForm(isCurrentTaxYear: String, iabdType: String, formType: String): Action[AnyContent] =
     (authenticate andThen noSessionCheck).async { implicit request =>
-      val taxYearRange  = controllersReferenceData.yearRange
-      val iabdTypeValue = uriInformation.iabdValueURLDeMapper(iabdType)
+      val taxYearRange                 = controllersReferenceData.yearRange
+      val iabdTypeValue                = uriInformation.iabdValueURLDeMapper(iabdType)
       val resultFuture: Future[Result] = for {
         _ <- validateRequest(isCurrentTaxYear, iabdType)
       } yield formType match {
@@ -281,9 +281,9 @@ class ExclusionListController @Inject() (
     (authenticate andThen noSessionCheck).async { implicit request =>
       implicit val hc: HeaderCarrier =
         HeaderCarrierConverter.fromRequestAndSession(request, request.session)
-      val iabdTypeValue: String = uriInformation.iabdValueURLDeMapper(iabdType)
+      val iabdTypeValue: String      = uriInformation.iabdValueURLDeMapper(iabdType)
       if (exclusionsAllowed) {
-        val form: Form[EiLPerson] = formType match {
+        val form: Form[EiLPerson]        = formType match {
           case ControllersReferenceDataCodes.FORM_TYPE_NINO   => formMappings.exclusionSearchFormWithNino
           case ControllersReferenceDataCodes.FORM_TYPE_NONINO => formMappings.exclusionSearchFormWithoutNino
         }
@@ -473,7 +473,8 @@ class ExclusionListController @Inject() (
                   )
                 ),
               values => {
-                val individualsDetails: EiLPerson = session.get.listOfMatches.get.find(person => person.nino == values.nino).get
+                val individualsDetails: EiLPerson     =
+                  session.get.listOfMatches.get.find(person => person.nino == values.nino).get
                 val excludedPerson: Option[EiLPerson] = createExcludedPerson(individualsDetails)
                 validateRequest(year, iabdType).flatMap { _ =>
                   commitExclusion(

--- a/app/controllers/HomePageController.scala
+++ b/app/controllers/HomePageController.scala
@@ -84,7 +84,7 @@ class HomePageController @Inject() (
 
   def onPageLoad: Action[AnyContent] = (authenticate andThen noSessionCheck).async { implicit request =>
     cachingService.resetAll()
-    val taxYearRange: TaxYearRange = taxDateUtils.getTaxYearRange()
+    val taxYearRange: TaxYearRange     = taxDateUtils.getTaxYearRange()
     val pageLoadFuture: Future[Result] = for {
       // Get the available count of biks available for each tax year
       biksListOptionCY: List[Bik]                       <-

--- a/app/controllers/StartPageController.scala
+++ b/app/controllers/StartPageController.scala
@@ -24,7 +24,7 @@ import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.StartPage
 
 import javax.inject.{Inject, Singleton}
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 
 @Singleton
 class StartPageController @Inject() (

--- a/app/views/registration/RemoveBenefitNextTaxYear.scala.html
+++ b/app/views/registration/RemoveBenefitNextTaxYear.scala.html
@@ -60,14 +60,13 @@
         </div>
     }
 
-    <legend><h1 id="title" class="govuk-heading-xl">
-        @messages("RemoveBenefits.Confirm.Heading", benefitLabel)
-    </h1></legend>
-
     <div class="data">
         @formWithCSRF(action = controllers.registration.routes.ManageRegistrationController.removeNextYearRegisteredBenefitTypes(removalBik.get.id), 'id -> "form-remove") {
             <div class='govuk-form-group @if(form.hasErrors) {govuk-form-group--error}'>
                 <fieldset class="govuk-fieldset" @if(form.hasErrors) { aria-describedby="error-list-1" }>
+                    <legend><h1 id="title" class="govuk-heading-xl">
+                        @messages("RemoveBenefits.Confirm.Heading", benefitLabel)
+                    </h1></legend>
                     @if(form.hasErrors) {
                         <span id="error-list-1" class="govuk-error-message">
                             @if(form.errors.head.message == "error.required") {@Messages("RemoveBenefits.reason.no.selection")

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ lazy val scoverageSettings: Seq[Def.Setting[_]] =
     ScoverageKeys.coverageExcludedPackages := "<empty>;Reverse.*;models/.data/..*;views.*;config.*;models.*;" +
       ".*(AuthService|BuildInfo|Routes).*",
     ScoverageKeys.coverageMinimumStmtTotal := 87,
-    ScoverageKeys.coverageFailOnMinimum := false,
+    ScoverageKeys.coverageFailOnMinimum := true,
     ScoverageKeys.coverageHighlighting := true
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -43,8 +43,9 @@ lazy val microservice = Project(appName, file("."))
   )
 
 scalacOptions ++= Seq(
-  "-P:silencer:globalFilters=Unused import",
-  "-feature"
+  "-feature",
+  "-Wconf:src=routes/.*:s",
+  "-Wconf:cat=unused-imports&src=html/.*:s"
 )
 
 addCommandAlias("scalafmtAll", "all scalafmtSbt scalafmt test:scalafmt")

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,26 +2,26 @@ import sbt._
 
 object AppDependencies {
 
-  val silencerVersion = "1.7.9"
+  val silencerVersion = "1.7.12"
 
   val compile: Seq[ModuleID] = Seq(
-    "uk.gov.hmrc"    %% "play-partials"              % "8.2.0-play-28",
-    "uk.gov.hmrc"    %% "url-builder"                % "3.5.0-play-28",
+    "uk.gov.hmrc"    %% "play-partials"              % "8.3.0-play-28",
+    "uk.gov.hmrc"    %% "url-builder"                % "3.6.0-play-28",
     "uk.gov.hmrc"    %% "tax-year"                   % "3.0.0",
-    "uk.gov.hmrc"    %% "bootstrap-frontend-play-28" % "7.2.0",
-    "uk.gov.hmrc"    %% "play-frontend-hmrc"         % "3.24.0-play-28",
-    "uk.gov.hmrc"    %% "http-caching-client"        % "9.5.0-play-28",
+    "uk.gov.hmrc"    %% "bootstrap-frontend-play-28" % "7.11.0",
+    "uk.gov.hmrc"    %% "play-frontend-hmrc"         % "3.32.0-play-28",
+    "uk.gov.hmrc"    %% "http-caching-client"        % "10.0.0-play-28",
     compilerPlugin("com.github.ghik" % "silencer-plugin" % silencerVersion cross CrossVersion.full),
     "com.github.ghik" % "silencer-lib"               % silencerVersion % Provided cross CrossVersion.full
   )
 
   val test: Seq[ModuleID] = Seq(
-    "org.mockito"                   % "mockito-core"         % "4.7.0",
-    "org.specs2"                   %% "specs2-core"          % "4.16.1",
+    "org.mockito"                   % "mockito-core"         % "4.8.1",
+    "org.specs2"                   %% "specs2-core"          % "4.18.0",
     "org.jsoup"                     % "jsoup"                % "1.15.3",
     "org.scalatestplus.play"       %% "scalatestplus-play"   % "5.1.0",
-    "org.scalatest"                %% "scalatest"            % "3.2.13",
-    "org.scalatestplus"            %% "mockito-4-6"          % "3.2.13.0",
+    "org.scalatest"                %% "scalatest"            % "3.2.14",
+    "org.scalatestplus"            %% "mockito-4-6"          % "3.2.14.0",
     "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.13.4",
     "com.vladsch.flexmark"          % "flexmark-all"         % "0.62.2"
   ).map(_ % "test")

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,17 +2,13 @@ import sbt._
 
 object AppDependencies {
 
-  val silencerVersion = "1.7.12"
-
   val compile: Seq[ModuleID] = Seq(
-    "uk.gov.hmrc"    %% "play-partials"              % "8.3.0-play-28",
-    "uk.gov.hmrc"    %% "url-builder"                % "3.6.0-play-28",
-    "uk.gov.hmrc"    %% "tax-year"                   % "3.0.0",
-    "uk.gov.hmrc"    %% "bootstrap-frontend-play-28" % "7.11.0",
-    "uk.gov.hmrc"    %% "play-frontend-hmrc"         % "3.32.0-play-28",
-    "uk.gov.hmrc"    %% "http-caching-client"        % "10.0.0-play-28",
-    compilerPlugin("com.github.ghik" % "silencer-plugin" % silencerVersion cross CrossVersion.full),
-    "com.github.ghik" % "silencer-lib"               % silencerVersion % Provided cross CrossVersion.full
+    "uk.gov.hmrc" %% "play-partials"              % "8.3.0-play-28",
+    "uk.gov.hmrc" %% "url-builder"                % "3.6.0-play-28",
+    "uk.gov.hmrc" %% "tax-year"                   % "3.0.0",
+    "uk.gov.hmrc" %% "bootstrap-frontend-play-28" % "7.11.0",
+    "uk.gov.hmrc" %% "play-frontend-hmrc"         % "3.32.0-play-28",
+    "uk.gov.hmrc" %% "http-caching-client"        % "10.0.0-play-28"
   )
 
   val test: Seq[ModuleID] = Seq(

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -22,7 +22,7 @@ object AppDependencies {
     "org.scalatestplus.play"       %% "scalatestplus-play"   % "5.1.0",
     "org.scalatest"                %% "scalatest"            % "3.2.14",
     "org.scalatestplus"            %% "mockito-4-6"          % "3.2.14.0",
-    "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.13.4",
+    "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.14.0",
     "com.vladsch.flexmark"          % "flexmark-all"         % "0.62.2"
   ).map(_ % "test")
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.2
+sbt.version=1.7.2

--- a/test/builders/SessionBuilder.scala
+++ b/test/builders/SessionBuilder.scala
@@ -17,8 +17,7 @@
 package builders
 
 import java.util.UUID
-
-import play.api.mvc.AnyContentAsJson
+import play.api.mvc.{AnyContentAsEmpty, AnyContentAsJson}
 import play.api.test.FakeRequest
 import uk.gov.hmrc.http.SessionKeys
 
@@ -29,7 +28,7 @@ object SessionBuilder {
     fakeRequest.withSession(SessionKeys.sessionId -> sessionId)
   }
 
-  def buildRequestWithSession() = {
+  def buildRequestWithSession(): FakeRequest[AnyContentAsEmpty.type] = {
     val sessionId = s"session-${UUID.randomUUID}"
     FakeRequest().withSession(SessionKeys.sessionId -> sessionId)
   }

--- a/test/connectors/TierConnectorSpec.scala
+++ b/test/connectors/TierConnectorSpec.scala
@@ -19,6 +19,7 @@ package connectors
 import controllers.FakePBIKApplication
 import models.{EmpRef, PbikError}
 import org.scalatestplus.play.PlaySpec
+import play.api.http.Status.{INTERNAL_SERVER_ERROR, OK}
 import play.api.libs.json.Json
 import play.api.mvc.Results
 import support.TestAuthUser
@@ -27,26 +28,29 @@ import utils.Exceptions.GenericServerErrorException
 
 class TierConnectorSpec extends PlaySpec with FakePBIKApplication with TestAuthUser with Results {
 
-  val fakeResponse: HttpResponse = HttpResponse(200, "")
+  val fakeResponse: HttpResponse = HttpResponse(OK, "")
 
   val fakeResponseWithError: HttpResponse =
-    HttpResponse(200, Json.toJson(new PbikError("64990")), Map.empty[String, Seq[String]])
+    HttpResponse(OK, Json.toJson(new PbikError("64990")), Map.empty[String, Seq[String]])
 
-  val fakeSevereResponse: HttpResponse = HttpResponse(500, "A severe server error")
+  val fakeSevereResponse: HttpResponse = HttpResponse(INTERNAL_SERVER_ERROR, "A severe server error")
 
   val hmrcTierConnector = app.injector.instanceOf[HmrcTierConnector]
 
+  val year = 2015
+
   "When creating a GET URL with an orgainsation needing encoding it" should {
     " encode the slash properly" in {
+
       val result: String =
-        hmrcTierConnector.createGetUrl("theBaseUrl", "theURIExtension", EmpRef("780", "MODES16"), 2015)
+        hmrcTierConnector.createGetUrl("theBaseUrl", "theURIExtension", EmpRef("780", "MODES16"), year)
       assert(result == "theBaseUrl/780%2FMODES16/2015/theURIExtension")
     }
   }
 
   "When creating a GET URL with no organisation it" should {
     " omit the organisation" in {
-      val result: String = hmrcTierConnector.createGetUrl("theBaseUrl", "theURIExtension", EmpRef.empty, 2015)
+      val result: String = hmrcTierConnector.createGetUrl("theBaseUrl", "theURIExtension", EmpRef.empty, year)
       assert(result == "theBaseUrl/2015/theURIExtension")
     }
   }
@@ -54,7 +58,7 @@ class TierConnectorSpec extends PlaySpec with FakePBIKApplication with TestAuthU
   "When creating a POST URL with an organisation which needs encoding it" should {
     " be properly formed with the %2F encoding" in {
       val result: String =
-        hmrcTierConnector.createPostUrl("theBaseUrl", "theURIExtension", EmpRef("780", "MODES16"), 2015)
+        hmrcTierConnector.createPostUrl("theBaseUrl", "theURIExtension", EmpRef("780", "MODES16"), year)
       assert(result == "theBaseUrl/780%2FMODES16/2015/theURIExtension")
     }
   }
@@ -70,7 +74,7 @@ class TierConnectorSpec extends PlaySpec with FakePBIKApplication with TestAuthU
   "When processing a response if the status is less than 400 it" should {
     " return the response" in {
       val resp = hmrcTierConnector.processResponse(fakeResponse)
-      assert(resp.status == 200)
+      assert(resp.status == OK)
     }
   }
 

--- a/test/controllers/ExclusionListControllerSpec.scala
+++ b/test/controllers/ExclusionListControllerSpec.scala
@@ -68,10 +68,11 @@ class ExclusionListControllerSpec extends PlaySpec with FakePBIKApplication with
   } else {
     models.TaxYearRange(date.getYear, date.getYear + 1, date.getYear + 2)
   }
+  val eilPersonStatus = 10
 
   lazy val ListOfPeople: List[EiLPerson] = List(
-    EiLPerson("AA111111", "John", Some("Stones"), "Smith", Some("123"), Some("01/01/1980"), Some("male"), Some(10), 0),
-    EiLPerson("AB111111", "Adam", None, "Smith", None, Some("01/01/1980"), Some("male"), None, 0),
+    EiLPerson("AA111111", "John", Some("Stones"), "Smith", Some("123"), Some("01/01/1980"), Some("male"), Some(10)),
+    EiLPerson("AB111111", "Adam", None, "Smith", None, Some("01/01/1980"), Some("male"), None),
     EiLPerson(
       "AC111111",
       "Humpty",
@@ -80,10 +81,9 @@ class ExclusionListControllerSpec extends PlaySpec with FakePBIKApplication with
       Some("123"),
       Some("01/01/1980"),
       Some("male"),
-      Some(10),
-      0
+      Some(eilPersonStatus)
     ),
-    EiLPerson("AD111111", "Peter", Some("James"), "Johnson", None, None, None, None, 0),
+    EiLPerson("AD111111", "Peter", Some("James"), "Johnson", None, None, None, None),
     EiLPerson(
       "AE111111",
       "Alice",
@@ -92,8 +92,7 @@ class ExclusionListControllerSpec extends PlaySpec with FakePBIKApplication with
       Some("123"),
       Some("03/02/1978"),
       Some("female"),
-      Some(10),
-      0
+      Some(eilPersonStatus)
     ),
     EiLPerson(
       "AF111111",
@@ -103,8 +102,7 @@ class ExclusionListControllerSpec extends PlaySpec with FakePBIKApplication with
       Some("123"),
       Some("01/01/1980"),
       Some("male"),
-      Some(10),
-      0
+      Some(eilPersonStatus)
     )
   )
 
@@ -535,7 +533,7 @@ class ExclusionListControllerSpec extends PlaySpec with FakePBIKApplication with
             )
           )
         )
-      lazy val ninoSearchPerson                                         = EiLPerson("AB111111", "Adam", None, "Smith", None, None, None, None, 0)
+      lazy val ninoSearchPerson                                         = EiLPerson("AB111111", "Adam", None, "Smith", None, None, None, None)
       lazy val formData                                                 =
         controllersReferenceData.exclusionSearchFormWithNino(request = mockrequest).fill(ninoSearchPerson)
       implicit val formrequest: FakeRequest[AnyContentAsFormUrlEncoded] =
@@ -553,7 +551,7 @@ class ExclusionListControllerSpec extends PlaySpec with FakePBIKApplication with
     "see the expected search results page" in {
 
       val noNinoSearchPerson                                            =
-        EiLPerson("AB111111", "Adam", None, "Smith", None, Some("01/01/1980"), Some("male"), None, 0)
+        EiLPerson("AB111111", "Adam", None, "Smith", None, Some("01/01/1980"), Some("male"), None)
       val formData                                                      =
         controllersReferenceData.exclusionSearchFormWithoutNino(request = mockrequest).fill(noNinoSearchPerson)
       implicit val formrequest: FakeRequest[AnyContentAsFormUrlEncoded] =
@@ -1099,7 +1097,7 @@ class ExclusionListControllerSpec extends PlaySpec with FakePBIKApplication with
   "When updating exclusions," must {
     "an invalid input on first name" in {
       val TEST_EIL_PERSON: List[EiLPerson]                              = List(
-        EiLPerson("AA111111", " ", Some("Stones"), "Smith", Some("123"), Some("01/01/1980"), Some("male"), Some(10), 0)
+        EiLPerson("AA111111", " ", Some("Stones"), "Smith", Some("123"), Some("01/01/1980"), Some("male"), Some(10))
       )
       val TEST_YEAR_CODE                                                = "cy"
       val TEST_IABD_VALUE                                               = "car"

--- a/test/controllers/ExclusionListControllerSpec.scala
+++ b/test/controllers/ExclusionListControllerSpec.scala
@@ -68,7 +68,7 @@ class ExclusionListControllerSpec extends PlaySpec with FakePBIKApplication with
   } else {
     models.TaxYearRange(date.getYear, date.getYear + 1, date.getYear + 2)
   }
-  val eilPersonStatus = 10
+  val eilPersonStatus                                    = 10
 
   lazy val ListOfPeople: List[EiLPerson] = List(
     EiLPerson("AA111111", "John", Some("Stones"), "Smith", Some("123"), Some("01/01/1980"), Some("male"), Some(10)),

--- a/test/controllers/HomePageControllerSpec.scala
+++ b/test/controllers/HomePageControllerSpec.scala
@@ -19,7 +19,6 @@ package controllers
 import config.{AppConfig, PbikAppConfig}
 import connectors.HmrcTierConnector
 import controllers.actions.{AuthAction, NoSessionCheckAction}
-import models._
 import org.mockito.Mockito._
 import org.scalatestplus.play.PlaySpec
 import play.api.Application
@@ -54,7 +53,6 @@ class HomePageControllerSpec extends PlaySpec with FakePBIKApplication with Test
     .build()
 
   implicit val taxDateUtils: TaxDateUtils = app.injector.instanceOf[TaxDateUtils]
-  def YEAR_RANGE: TaxYearRange            = taxDateUtils.getTaxYearRange()
 
   "When checking if from YTA referer ends /account" in {
     val homePageController                                    = app.injector.instanceOf[HomePageController]

--- a/test/controllers/LanguageSupportSpec.scala
+++ b/test/controllers/LanguageSupportSpec.scala
@@ -31,7 +31,6 @@ import services.{BikListService, RegistrationService}
 import support.{StubbedBikListService, StubbedRegistrationService, TestAuthUser}
 import uk.gov.hmrc.http.SessionKeys
 import utils.{TestAuthAction, TestNoSessionCheckAction}
-import scala.language.postfixOps
 
 class LanguageSupportSpec extends PlaySpec with TestAuthUser with FakePBIKApplication {
 

--- a/test/controllers/LanguageSupportSpec.scala
+++ b/test/controllers/LanguageSupportSpec.scala
@@ -19,7 +19,6 @@ package controllers
 import config.{AppConfig, PbikAppConfig}
 import connectors.HmrcTierConnector
 import controllers.actions.{AuthAction, NoSessionCheckAction}
-import models.{Bik, TaxYearRange}
 import org.mockito.Mockito._
 import org.scalatestplus.play.PlaySpec
 import play.api.Application
@@ -31,9 +30,7 @@ import play.api.test.Helpers._
 import services.{BikListService, RegistrationService}
 import support.{StubbedBikListService, StubbedRegistrationService, TestAuthUser}
 import uk.gov.hmrc.http.SessionKeys
-import utils.{FormMappings, TaxDateUtils, TestAuthAction, TestNoSessionCheckAction}
-
-import scala.concurrent.duration.{DurationInt, FiniteDuration}
+import utils.{TestAuthAction, TestNoSessionCheckAction}
 import scala.language.postfixOps
 
 class LanguageSupportSpec extends PlaySpec with TestAuthUser with FakePBIKApplication {
@@ -46,14 +43,6 @@ class LanguageSupportSpec extends PlaySpec with TestAuthUser with FakePBIKApplic
     .overrides(bind[AuthAction].to(classOf[TestAuthAction]))
     .overrides(bind[NoSessionCheckAction].to(classOf[TestNoSessionCheckAction]))
     .build()
-
-  implicit val taxDateUtils: TaxDateUtils = app.injector.instanceOf[TaxDateUtils]
-  val formMappings: FormMappings          = app.injector.instanceOf[FormMappings]
-
-  lazy val CYCache: List[Bik]      = List.tabulate(21)(n => Bik("" + (n + 1), 10))
-  val timeoutValue: FiniteDuration = 15 seconds
-
-  def YEAR_RANGE: TaxYearRange = taxDateUtils.getTaxYearRange()
 
   "The Homepage Controller" should {
     "set the request language and reload page based on referer header" in {
@@ -77,7 +66,7 @@ class LanguageSupportSpec extends PlaySpec with TestAuthUser with FakePBIKApplic
 
       val result = homePageController.onPageLoad(request)
 
-      status(result)          must be(OK) // 200
+      status(result)          must be(OK)
       contentAsString(result) must include("Cyfeirnod TWE y cyflogwr")
     }
   }

--- a/test/controllers/WhatNextPageControllerSpec.scala
+++ b/test/controllers/WhatNextPageControllerSpec.scala
@@ -108,7 +108,7 @@ class WhatNextPageControllerSpec extends PlaySpec with FakePBIKApplication with 
   )
   lazy val CYCache: List[Bik]                    = List.tabulate(21)(n => Bik("" + (n + 1), 10))
 
-  def YEAR_RANGE: TaxYearRange = taxDateUtils.getTaxYearRange()
+  def yearRange: TaxYearRange = taxDateUtils.getTaxYearRange()
 
   class StubBikListService @Inject() (
     pbikAppConfig: AppConfig,
@@ -151,7 +151,7 @@ class WhatNextPageControllerSpec extends PlaySpec with FakePBIKApplication with 
       )
 
     when(
-      tierConnector.genericGetCall[List[Bik]](any[String], any[String], any[EmpRef], argEq(YEAR_RANGE.cy))(
+      tierConnector.genericGetCall[List[Bik]](any[String], any[String], any[EmpRef], argEq(yearRange.cy))(
         any[HeaderCarrier],
         any[json.Format[List[Bik]]]
       )
@@ -160,7 +160,7 @@ class WhatNextPageControllerSpec extends PlaySpec with FakePBIKApplication with 
     }))
 
     when(
-      tierConnector.genericGetCall[List[Bik]](any[String], any[String], any[EmpRef], argEq(YEAR_RANGE.cyminus1))(
+      tierConnector.genericGetCall[List[Bik]](any[String], any[String], any[EmpRef], argEq(yearRange.cyminus1))(
         any[HeaderCarrier],
         any[json.Format[List[Bik]]]
       )
@@ -169,7 +169,7 @@ class WhatNextPageControllerSpec extends PlaySpec with FakePBIKApplication with 
     }))
 
     when(
-      tierConnector.genericGetCall[List[Bik]](any[String], any[String], any[EmpRef], argEq(YEAR_RANGE.cyplus1))(
+      tierConnector.genericGetCall[List[Bik]](any[String], any[String], any[EmpRef], argEq(yearRange.cyplus1))(
         any[HeaderCarrier],
         any[json.Format[List[Bik]]]
       )
@@ -178,7 +178,7 @@ class WhatNextPageControllerSpec extends PlaySpec with FakePBIKApplication with 
     }))
 
     when(
-      tierConnector.genericGetCall[List[Bik]](any[String], argEq(""), any[EmpRef], argEq(YEAR_RANGE.cy))(
+      tierConnector.genericGetCall[List[Bik]](any[String], argEq(""), any[EmpRef], argEq(yearRange.cy))(
         any[HeaderCarrier],
         any[json.Format[List[Bik]]]
       )
@@ -191,7 +191,7 @@ class WhatNextPageControllerSpec extends PlaySpec with FakePBIKApplication with 
         any[String],
         argEq(app.injector.instanceOf[URIInformation].getBenefitTypesPath),
         argEq(EmpRef.empty),
-        argEq(YEAR_RANGE.cy)
+        argEq(yearRange.cy)
       )(any[HeaderCarrier], any[json.Format[List[Bik]]])
     )
       .thenReturn(Future.successful(CYCache.filter { x: Bik =>
@@ -203,7 +203,7 @@ class WhatNextPageControllerSpec extends PlaySpec with FakePBIKApplication with 
         any[String],
         argEq(app.injector.instanceOf[URIInformation].getBenefitTypesPath),
         argEq(EmpRef.empty),
-        argEq(YEAR_RANGE.cyminus1)
+        argEq(yearRange.cyminus1)
       )(any[HeaderCarrier], any[json.Format[List[Bik]]])
     )
       .thenReturn(Future.successful(CYCache.filter { x: Bik =>
@@ -215,7 +215,7 @@ class WhatNextPageControllerSpec extends PlaySpec with FakePBIKApplication with 
         any[String],
         argEq(app.injector.instanceOf[URIInformation].getBenefitTypesPath),
         argEq(EmpRef.empty),
-        argEq(YEAR_RANGE.cyplus1)
+        argEq(yearRange.cyplus1)
       )(any[HeaderCarrier], any[json.Format[List[Bik]]])
     )
       .thenReturn(Future.successful(CYCache.filter { x: Bik =>
@@ -266,7 +266,7 @@ class WhatNextPageControllerSpec extends PlaySpec with FakePBIKApplication with 
     val w = app.injector.instanceOf[WhatNextPageController]
 
     when(
-      w.tierConnector.genericGetCall[List[Bik]](any[String], argEq(""), any[EmpRef], argEq(YEAR_RANGE.cy))(
+      w.tierConnector.genericGetCall[List[Bik]](any[String], argEq(""), any[EmpRef], argEq(yearRange.cy))(
         any[HeaderCarrier],
         any[json.Format[List[Bik]]]
       )
@@ -279,7 +279,7 @@ class WhatNextPageControllerSpec extends PlaySpec with FakePBIKApplication with 
         any[String],
         argEq(injected[URIInformation].getBenefitTypesPath),
         argEq(EmpRef.empty),
-        argEq(YEAR_RANGE.cy)
+        argEq(yearRange.cy)
       )(any[HeaderCarrier], any[json.Format[List[Bik]]])
     )
       .thenReturn(Future.successful(CYCache.filter { x: Bik =>
@@ -291,7 +291,7 @@ class WhatNextPageControllerSpec extends PlaySpec with FakePBIKApplication with 
         any[String],
         argEq(injected[URIInformation].getBenefitTypesPath),
         argEq(EmpRef.empty),
-        argEq(YEAR_RANGE.cyminus1)
+        argEq(yearRange.cyminus1)
       )(any[HeaderCarrier], any[json.Format[List[Bik]]])
     )
       .thenReturn(Future.successful(CYCache.filter { x: Bik =>
@@ -303,7 +303,7 @@ class WhatNextPageControllerSpec extends PlaySpec with FakePBIKApplication with 
         any[String],
         argEq(injected[URIInformation].getBenefitTypesPath),
         argEq(EmpRef.empty),
-        argEq(YEAR_RANGE.cyplus1)
+        argEq(yearRange.cyplus1)
       )(any[HeaderCarrier], any[json.Format[List[Bik]]])
     )
       .thenReturn(Future.successful(CYCache.filter { x: Bik =>
@@ -424,7 +424,6 @@ class WhatNextPageControllerSpec extends PlaySpec with FakePBIKApplication with 
     implicit val request: FakeRequest[AnyContentAsEmpty.type]           = mockrequest
     implicit val authenticatedRequest: AuthenticatedRequest[AnyContent] =
       AuthenticatedRequest(EmpRef("taxOfficeNumber", "taxOfficeReference"), UserName(Name(None, None)), request)
-    val whatNextRemoveMsg: String                                       = messagesApi("whatNext.remove.p")
     val result                                                          = whatNextPageController.showWhatNextRemovedBik("medical").apply(authenticatedRequest)
     (scala.concurrent.ExecutionContext.Implicits.global)
     status(result)          must be(OK)

--- a/test/controllers/WhatNextPageControllerSpec.scala
+++ b/test/controllers/WhatNextPageControllerSpec.scala
@@ -34,6 +34,8 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import services.{BikListService, SessionService}
 import support.TestAuthUser
+import play.api.http.Status
+import play.api.libs.json.Json
 import uk.gov.hmrc.auth.core.retrieve.Name
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.time.TaxYear
@@ -55,13 +57,15 @@ class WhatNextPageControllerSpec extends PlaySpec with FakePBIKApplication with 
     .overrides(bind[SessionService].toInstance(mock(classOf[SessionService])))
     .build()
 
-  implicit val lang = Lang("en-GB")
-  val messagesApi   = app.injector.instanceOf[MessagesApi]
+  implicit val lang: Lang = Lang("en-GB")
+  val messagesApi         = app.injector.instanceOf[MessagesApi]
 
   val formMappings: FormMappings = app.injector.instanceOf[FormMappings]
   val taxDateUtils: TaxDateUtils = app.injector.instanceOf[TaxDateUtils]
   val eilStatus                  = 10
   val year2020                   = 2020
+
+  val response = HttpResponse(Status.OK, Json.obj().toString())
 
   lazy val listOfPeople: List[EiLPerson] = List(
     EiLPerson(
@@ -249,7 +253,7 @@ class WhatNextPageControllerSpec extends PlaySpec with FakePBIKApplication with 
         any
       )(any[HeaderCarrier], any[Request[_]], any[json.Format[List[Bik]]])
     )
-      .thenReturn(Future.successful(new FakeResponse()))
+      .thenReturn(Future.successful(response))
 
     when(
       tierConnector.genericGetCall[List[Bik]](
@@ -263,12 +267,6 @@ class WhatNextPageControllerSpec extends PlaySpec with FakePBIKApplication with 
         Integer.parseInt(x.iabdType) >= 15
       }))
 
-  }
-
-  class FakeResponse extends HttpResponse {
-    override def status: Int                          = OK
-    override def allHeaders: Map[String, Seq[String]] = Map()
-    override def body: String                         = "empty"
   }
 
   val whatNextPageController: WhatNextPageController = {
@@ -338,7 +336,7 @@ class WhatNextPageControllerSpec extends PlaySpec with FakePBIKApplication with 
           any
         )(any[HeaderCarrier], any[Request[_]], any[json.Format[List[Bik]]])
     )
-      .thenReturn(Future.successful(new FakeResponse()))
+      .thenReturn(Future.successful(response))
 
     when(
       w.tierConnector.genericGetCall[List[Bik]](

--- a/test/controllers/WhatNextPageControllerSpec.scala
+++ b/test/controllers/WhatNextPageControllerSpec.scala
@@ -60,9 +60,21 @@ class WhatNextPageControllerSpec extends PlaySpec with FakePBIKApplication with 
 
   val formMappings: FormMappings = app.injector.instanceOf[FormMappings]
   val taxDateUtils: TaxDateUtils = app.injector.instanceOf[TaxDateUtils]
+  val eilStatus                  = 10
+  val year2020                   = 2020
 
   lazy val listOfPeople: List[EiLPerson] = List(
-    EiLPerson("AA111111", "John", Some("Stones"), "Smith", Some("123"), Some("01/01/1980"), Some("male"), Some(10), 0),
+    EiLPerson(
+      "AA111111",
+      "John",
+      Some("Stones"),
+      "Smith",
+      Some("123"),
+      Some("01/01/1980"),
+      Some("male"),
+      Some(eilStatus),
+      0
+    ),
     EiLPerson("AB111111", "Adam", None, "Smith", None, Some("01/01/1980"), Some("male"), None, 0),
     EiLPerson(
       "AC111111",
@@ -72,7 +84,7 @@ class WhatNextPageControllerSpec extends PlaySpec with FakePBIKApplication with 
       Some("123"),
       Some("01/01/1980"),
       Some("male"),
-      Some(10),
+      Some(eilStatus),
       0
     ),
     EiLPerson("AD111111", "Peter", Some("James"), "Johnson", None, None, None, None, 0),
@@ -84,7 +96,7 @@ class WhatNextPageControllerSpec extends PlaySpec with FakePBIKApplication with 
       Some("123"),
       Some("03/02/1978"),
       Some("female"),
-      Some(10),
+      Some(eilStatus),
       0
     ),
     EiLPerson(
@@ -95,7 +107,7 @@ class WhatNextPageControllerSpec extends PlaySpec with FakePBIKApplication with 
       Some("123"),
       Some("01/01/1980"),
       Some("male"),
-      Some(10),
+      Some(eilStatus),
       0
     )
   )
@@ -106,9 +118,9 @@ class WhatNextPageControllerSpec extends PlaySpec with FakePBIKApplication with 
     None,
     List(RegistrationItem("30", active = true, enabled = true), RegistrationItem("8", true, true))
   )
-  lazy val CYCache: List[Bik]                    = List.tabulate(21)(n => Bik("" + (n + 1), 10))
+  lazy val CYCache: List[Bik]                    = List.tabulate(21)(n => Bik("" + (n + 1), eilStatus))
 
-  def yearRange: TaxYearRange = taxDateUtils.getTaxYearRange()
+  def taxYearRange: TaxYearRange = taxDateUtils.getTaxYearRange()
 
   class StubBikListService @Inject() (
     pbikAppConfig: AppConfig,
@@ -122,7 +134,8 @@ class WhatNextPageControllerSpec extends PlaySpec with FakePBIKApplication with 
         uriInformation
       ) {
 
-    lazy val CYCache: List[Bik] = List.tabulate(21)(n => Bik("" + (n + 1), 10))
+    lazy val noOfElements       = 21
+    lazy val CYCache: List[Bik] = List.tabulate(noOfElements)(n => Bik("" + (n + 1), eilStatus))
 
     override def currentYearList(implicit
       hc: HeaderCarrier,
@@ -151,7 +164,7 @@ class WhatNextPageControllerSpec extends PlaySpec with FakePBIKApplication with 
       )
 
     when(
-      tierConnector.genericGetCall[List[Bik]](any[String], any[String], any[EmpRef], argEq(yearRange.cy))(
+      tierConnector.genericGetCall[List[Bik]](any[String], any[String], any[EmpRef], argEq(taxYearRange.cy))(
         any[HeaderCarrier],
         any[json.Format[List[Bik]]]
       )
@@ -160,7 +173,7 @@ class WhatNextPageControllerSpec extends PlaySpec with FakePBIKApplication with 
     }))
 
     when(
-      tierConnector.genericGetCall[List[Bik]](any[String], any[String], any[EmpRef], argEq(yearRange.cyminus1))(
+      tierConnector.genericGetCall[List[Bik]](any[String], any[String], any[EmpRef], argEq(taxYearRange.cyminus1))(
         any[HeaderCarrier],
         any[json.Format[List[Bik]]]
       )
@@ -169,7 +182,7 @@ class WhatNextPageControllerSpec extends PlaySpec with FakePBIKApplication with 
     }))
 
     when(
-      tierConnector.genericGetCall[List[Bik]](any[String], any[String], any[EmpRef], argEq(yearRange.cyplus1))(
+      tierConnector.genericGetCall[List[Bik]](any[String], any[String], any[EmpRef], argEq(taxYearRange.cyplus1))(
         any[HeaderCarrier],
         any[json.Format[List[Bik]]]
       )
@@ -178,7 +191,7 @@ class WhatNextPageControllerSpec extends PlaySpec with FakePBIKApplication with 
     }))
 
     when(
-      tierConnector.genericGetCall[List[Bik]](any[String], argEq(""), any[EmpRef], argEq(yearRange.cy))(
+      tierConnector.genericGetCall[List[Bik]](any[String], argEq(""), any[EmpRef], argEq(taxYearRange.cy))(
         any[HeaderCarrier],
         any[json.Format[List[Bik]]]
       )
@@ -191,7 +204,7 @@ class WhatNextPageControllerSpec extends PlaySpec with FakePBIKApplication with 
         any[String],
         argEq(app.injector.instanceOf[URIInformation].getBenefitTypesPath),
         argEq(EmpRef.empty),
-        argEq(yearRange.cy)
+        argEq(taxYearRange.cy)
       )(any[HeaderCarrier], any[json.Format[List[Bik]]])
     )
       .thenReturn(Future.successful(CYCache.filter { x: Bik =>
@@ -203,7 +216,7 @@ class WhatNextPageControllerSpec extends PlaySpec with FakePBIKApplication with 
         any[String],
         argEq(app.injector.instanceOf[URIInformation].getBenefitTypesPath),
         argEq(EmpRef.empty),
-        argEq(yearRange.cyminus1)
+        argEq(taxYearRange.cyminus1)
       )(any[HeaderCarrier], any[json.Format[List[Bik]]])
     )
       .thenReturn(Future.successful(CYCache.filter { x: Bik =>
@@ -215,7 +228,7 @@ class WhatNextPageControllerSpec extends PlaySpec with FakePBIKApplication with 
         any[String],
         argEq(app.injector.instanceOf[URIInformation].getBenefitTypesPath),
         argEq(EmpRef.empty),
-        argEq(yearRange.cyplus1)
+        argEq(taxYearRange.cyplus1)
       )(any[HeaderCarrier], any[json.Format[List[Bik]]])
     )
       .thenReturn(Future.successful(CYCache.filter { x: Bik =>
@@ -223,7 +236,7 @@ class WhatNextPageControllerSpec extends PlaySpec with FakePBIKApplication with 
       }))
 
     when(
-      tierConnector.genericGetCall[List[Bik]](any[String], any[String], any[EmpRef], argEq(2020))(
+      tierConnector.genericGetCall[List[Bik]](any[String], any[String], any[EmpRef], argEq(year2020))(
         any[HeaderCarrier],
         any[json.Format[List[Bik]]]
       )
@@ -257,7 +270,7 @@ class WhatNextPageControllerSpec extends PlaySpec with FakePBIKApplication with 
   }
 
   class FakeResponse extends HttpResponse {
-    override def status                               = 200
+    override def status: Int                          = OK
     override def allHeaders: Map[String, Seq[String]] = Map()
     override def body: String                         = "empty"
   }
@@ -266,7 +279,7 @@ class WhatNextPageControllerSpec extends PlaySpec with FakePBIKApplication with 
     val w = app.injector.instanceOf[WhatNextPageController]
 
     when(
-      w.tierConnector.genericGetCall[List[Bik]](any[String], argEq(""), any[EmpRef], argEq(yearRange.cy))(
+      w.tierConnector.genericGetCall[List[Bik]](any[String], argEq(""), any[EmpRef], argEq(taxYearRange.cy))(
         any[HeaderCarrier],
         any[json.Format[List[Bik]]]
       )
@@ -279,7 +292,7 @@ class WhatNextPageControllerSpec extends PlaySpec with FakePBIKApplication with 
         any[String],
         argEq(injected[URIInformation].getBenefitTypesPath),
         argEq(EmpRef.empty),
-        argEq(yearRange.cy)
+        argEq(taxYearRange.cy)
       )(any[HeaderCarrier], any[json.Format[List[Bik]]])
     )
       .thenReturn(Future.successful(CYCache.filter { x: Bik =>
@@ -291,7 +304,7 @@ class WhatNextPageControllerSpec extends PlaySpec with FakePBIKApplication with 
         any[String],
         argEq(injected[URIInformation].getBenefitTypesPath),
         argEq(EmpRef.empty),
-        argEq(yearRange.cyminus1)
+        argEq(taxYearRange.cyminus1)
       )(any[HeaderCarrier], any[json.Format[List[Bik]]])
     )
       .thenReturn(Future.successful(CYCache.filter { x: Bik =>
@@ -303,7 +316,7 @@ class WhatNextPageControllerSpec extends PlaySpec with FakePBIKApplication with 
         any[String],
         argEq(injected[URIInformation].getBenefitTypesPath),
         argEq(EmpRef.empty),
-        argEq(yearRange.cyplus1)
+        argEq(taxYearRange.cyplus1)
       )(any[HeaderCarrier], any[json.Format[List[Bik]]])
     )
       .thenReturn(Future.successful(CYCache.filter { x: Bik =>
@@ -311,7 +324,7 @@ class WhatNextPageControllerSpec extends PlaySpec with FakePBIKApplication with 
       }))
 
     when(
-      w.tierConnector.genericGetCall[List[Bik]](any[String], any[String], any[EmpRef], argEq(2020))(
+      w.tierConnector.genericGetCall[List[Bik]](any[String], any[String], any[EmpRef], argEq(year2020))(
         any[HeaderCarrier],
         any[json.Format[List[Bik]]]
       )
@@ -366,7 +379,7 @@ class WhatNextPageControllerSpec extends PlaySpec with FakePBIKApplication with 
     implicit val authenticatedRequest: AuthenticatedRequest[AnyContent] =
       AuthenticatedRequest(EmpRef("taxOfficeNumber", "taxOfficeReference"), UserName(Name(None, None)), request)
     val result                                                          = whatNextPageController.showWhatNextRegisteredBik("cy1").apply(authenticatedRequest)
-    (scala.concurrent.ExecutionContext.Implicits.global)
+    scala.concurrent.ExecutionContext.Implicits.global
     status(result)          must be(OK)
     contentAsString(result) must include("Registration complete")
     contentAsString(result) must include(
@@ -381,7 +394,12 @@ class WhatNextPageControllerSpec extends PlaySpec with FakePBIKApplication with 
           Some(
             PbikSession(
               Some(
-                RegistrationList(active = List(RegistrationItem("30", true, true), RegistrationItem("8", true, true)))
+                RegistrationList(active =
+                  List(
+                    RegistrationItem("30", active = true, enabled = true),
+                    RegistrationItem("8", active = true, enabled = true)
+                  )
+                )
               ),
               None,
               None,
@@ -397,7 +415,7 @@ class WhatNextPageControllerSpec extends PlaySpec with FakePBIKApplication with 
     implicit val authenticatedRequest: AuthenticatedRequest[AnyContent] =
       AuthenticatedRequest(EmpRef("taxOfficeNumber", "taxOfficeReference"), UserName(Name(None, None)), request)
     val result                                                          = whatNextPageController.showWhatNextRegisteredBik("cy1").apply(authenticatedRequest)
-    (scala.concurrent.ExecutionContext.Implicits.global)
+    scala.concurrent.ExecutionContext.Implicits.global
     status(result)          must be(OK)
     contentAsString(result) must include("Registration complete")
     contentAsString(result) must include("Private medical treatment or insurance")
@@ -411,7 +429,7 @@ class WhatNextPageControllerSpec extends PlaySpec with FakePBIKApplication with 
           Some(
             PbikSession(
               None,
-              Some(RegistrationItem("30", true, true)),
+              Some(RegistrationItem("30", active = true, enabled = true)),
               None,
               None,
               None,
@@ -425,7 +443,7 @@ class WhatNextPageControllerSpec extends PlaySpec with FakePBIKApplication with 
     implicit val authenticatedRequest: AuthenticatedRequest[AnyContent] =
       AuthenticatedRequest(EmpRef("taxOfficeNumber", "taxOfficeReference"), UserName(Name(None, None)), request)
     val result                                                          = whatNextPageController.showWhatNextRemovedBik("medical").apply(authenticatedRequest)
-    (scala.concurrent.ExecutionContext.Implicits.global)
+    scala.concurrent.ExecutionContext.Implicits.global
     status(result)          must be(OK)
     contentAsString(result) must include("Benefit removed")
     contentAsString(result) must include(
@@ -437,13 +455,13 @@ class WhatNextPageControllerSpec extends PlaySpec with FakePBIKApplication with 
     val startYear = TaxYear.taxYearFor(LocalDate.now())
 
     "return this tax year and next year if given true" in {
-      val result = whatNextPageController.calculateTaxYear(true)
+      val result: (Int, Int) = whatNextPageController.calculateTaxYear(isCurrentTaxYear = true)
       assert(result._1 == startYear.startYear)
       assert(result._2 == startYear.startYear + 1)
     }
 
     "return next year and the year after if given false" in {
-      val result = whatNextPageController.calculateTaxYear(false)
+      val result: (Int, Int) = whatNextPageController.calculateTaxYear(isCurrentTaxYear = false)
       assert(result._1 == startYear.startYear + 1)
       assert(result._2 == startYear.startYear + 2)
     }

--- a/test/controllers/WhatNextPageControllerSpec.scala
+++ b/test/controllers/WhatNextPageControllerSpec.scala
@@ -72,10 +72,9 @@ class WhatNextPageControllerSpec extends PlaySpec with FakePBIKApplication with 
       Some("123"),
       Some("01/01/1980"),
       Some("male"),
-      Some(eilStatus),
-      0
+      Some(eilStatus)
     ),
-    EiLPerson("AB111111", "Adam", None, "Smith", None, Some("01/01/1980"), Some("male"), None, 0),
+    EiLPerson("AB111111", "Adam", None, "Smith", None, Some("01/01/1980"), Some("male"), None),
     EiLPerson(
       "AC111111",
       "Humpty",
@@ -84,10 +83,9 @@ class WhatNextPageControllerSpec extends PlaySpec with FakePBIKApplication with 
       Some("123"),
       Some("01/01/1980"),
       Some("male"),
-      Some(eilStatus),
-      0
+      Some(eilStatus)
     ),
-    EiLPerson("AD111111", "Peter", Some("James"), "Johnson", None, None, None, None, 0),
+    EiLPerson("AD111111", "Peter", Some("James"), "Johnson", None, None, None, None),
     EiLPerson(
       "AE111111",
       "Alice",
@@ -96,8 +94,7 @@ class WhatNextPageControllerSpec extends PlaySpec with FakePBIKApplication with 
       Some("123"),
       Some("03/02/1978"),
       Some("female"),
-      Some(eilStatus),
-      0
+      Some(eilStatus)
     ),
     EiLPerson(
       "AF111111",
@@ -107,8 +104,7 @@ class WhatNextPageControllerSpec extends PlaySpec with FakePBIKApplication with 
       Some("123"),
       Some("01/01/1980"),
       Some("male"),
-      Some(eilStatus),
-      0
+      Some(eilStatus)
     )
   )
 
@@ -116,7 +112,7 @@ class WhatNextPageControllerSpec extends PlaySpec with FakePBIKApplication with 
   lazy val registrationList                      = RegistrationList(None, List(RegistrationItem("30", active = true, enabled = true)))
   lazy val registrationListMultiple              = RegistrationList(
     None,
-    List(RegistrationItem("30", active = true, enabled = true), RegistrationItem("8", true, true))
+    List(RegistrationItem("30", active = true, enabled = true), RegistrationItem("8", active = true, enabled = true))
   )
   lazy val CYCache: List[Bik]                    = List.tabulate(21)(n => Bik("" + (n + 1), eilStatus))
 
@@ -364,7 +360,7 @@ class WhatNextPageControllerSpec extends PlaySpec with FakePBIKApplication with 
         Future.successful(
           Some(
             PbikSession(
-              Some(RegistrationList(active = List(RegistrationItem("30", true, true)))),
+              Some(RegistrationList(active = List(RegistrationItem("30", active = true, enabled = true)))),
               None,
               None,
               None,

--- a/test/controllers/actions/AuthActionSpec.scala
+++ b/test/controllers/actions/AuthActionSpec.scala
@@ -28,7 +28,6 @@ import uk.gov.hmrc.auth.core.{InsufficientEnrolments, MissingBearerToken}
 import uk.gov.hmrc.http.HttpClient
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.language.postfixOps
 
 class AuthActionSpec extends PlaySpec with GuiceOneAppPerSuite with MockitoSugar {
 

--- a/test/services/BikListServiceSpec.scala
+++ b/test/services/BikListServiceSpec.scala
@@ -57,13 +57,17 @@ class BikListServiceSpec
   implicit lazy val aRequest: AuthenticatedRequest[AnyContentAsEmpty.type] = createDummyUser(mockrequest)
   implicit val hc: HeaderCarrier                                           = HeaderCarrier()
 
+  val bikStatus30 = 30
+  val bikStatus40 = 40
+  val bikEilCount = 10
+
   override def beforeEach(): Unit =
     reset(bikListService.tierConnector)
 
   "The BIK service" should {
 
     "Be able to get the BIKS for the current year - 2 returned" in {
-      val listBiks = List(Bik("Car & Car Fuel", 30, 10), Bik("Van Fuel", 40, 10))
+      val listBiks = List(Bik("Car & Car Fuel", bikStatus30, bikEilCount), Bik("Van Fuel", bikStatus40, bikEilCount))
 
       when(
         bikListService.tierConnector.genericGetCall[List[Bik]](any[String], any[String], any[EmpRef], any[Int])(
@@ -90,7 +94,7 @@ class BikListServiceSpec
     }
 
     "Be able to get the BIKS for the next year - 2 returned" in {
-      val listBiks = List(Bik("Car & Car Fuel", 30, 10), Bik("Van Fuel", 40, 10))
+      val listBiks = List(Bik("Car & Car Fuel", bikStatus30, bikEilCount), Bik("Van Fuel", bikStatus40, bikEilCount))
 
       when(
         bikListService.tierConnector.genericGetCall[List[Bik]](any[String], any[String], any[EmpRef], any[Int])(

--- a/test/services/EilListServiceSpec.scala
+++ b/test/services/EilListServiceSpec.scala
@@ -67,12 +67,12 @@ class EilListServiceSpec
 
   "When calling the EILService it" should {
     "return an empty list" in {
-      val eilService: EiLListService                                                 = MockEiLListService
-      implicit val hc: HeaderCarrier                                                 = HeaderCarrier(sessionId = Some(SessionId(sessionId)))
-      implicit val request: FakeRequest[AnyContentAsEmpty.type]                      = mockrequest
-      implicit val authenicatedRequest: AuthenticatedRequest[AnyContentAsEmpty.type] =
+      val eilService: EiLListService                                                  = MockEiLListService
+      implicit val hc: HeaderCarrier                                                  = HeaderCarrier(sessionId = Some(SessionId(sessionId)))
+      implicit val request: FakeRequest[AnyContentAsEmpty.type]                       = mockrequest
+      implicit val authenticatedRequest: AuthenticatedRequest[AnyContentAsEmpty.type] =
         AuthenticatedRequest(EmpRef("taxOfficeNumber", "taxOfficeReference"), UserName(Name(None, None)), request)
-      val result                                                                     = await(eilService.currentYearEiL("5", 2015))
+      val result                                                                      = await(eilService.currentYearEiL("5", 2015))
       result.size shouldBe 0
     }
 

--- a/test/services/EilListServiceSpec.scala
+++ b/test/services/EilListServiceSpec.scala
@@ -67,7 +67,7 @@ class EilListServiceSpec
 
   "When calling the EILService it" should {
     "return an empty list" in {
-      val year = 2015
+      val year                                                                        = 2015
       val eilService: EiLListService                                                  = MockEiLListService
       implicit val hc: HeaderCarrier                                                  = HeaderCarrier(sessionId = Some(SessionId(sessionId)))
       implicit val request: FakeRequest[AnyContentAsEmpty.type]                       = mockrequest

--- a/test/services/EilListServiceSpec.scala
+++ b/test/services/EilListServiceSpec.scala
@@ -67,12 +67,13 @@ class EilListServiceSpec
 
   "When calling the EILService it" should {
     "return an empty list" in {
+      val year = 2015
       val eilService: EiLListService                                                  = MockEiLListService
       implicit val hc: HeaderCarrier                                                  = HeaderCarrier(sessionId = Some(SessionId(sessionId)))
       implicit val request: FakeRequest[AnyContentAsEmpty.type]                       = mockrequest
       implicit val authenticatedRequest: AuthenticatedRequest[AnyContentAsEmpty.type] =
         AuthenticatedRequest(EmpRef("taxOfficeNumber", "taxOfficeReference"), UserName(Name(None, None)), request)
-      val result                                                                      = await(eilService.currentYearEiL("5", 2015))
+      val result                                                                      = await(eilService.currentYearEiL("5", year))
       result.size shouldBe 0
     }
 

--- a/test/services/RegistrationServiceSpec.scala
+++ b/test/services/RegistrationServiceSpec.scala
@@ -62,9 +62,9 @@ class RegistrationServiceSpec
 
   val registrationService: RegistrationService = {
 
-    val service = app.injector.instanceOf[RegistrationService]
+    val service      = app.injector.instanceOf[RegistrationService]
     val noOfElements = 5
-    val bikStatus = 10
+    val bikStatus    = 10
 
     lazy val CYCache: List[Bik] = List.tabulate(noOfElements)(n => Bik("" + (n + 1), bikStatus))
 

--- a/test/services/RegistrationServiceSpec.scala
+++ b/test/services/RegistrationServiceSpec.scala
@@ -26,6 +26,7 @@ import org.scalatest.OptionValues
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 import play.api.Application
+import play.api.http.Status.OK
 import play.api.i18n.{I18nSupport, Messages, MessagesApi}
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
@@ -62,8 +63,10 @@ class RegistrationServiceSpec
   val registrationService: RegistrationService = {
 
     val service = app.injector.instanceOf[RegistrationService]
+    val noOfElements = 5
+    val bikStatus = 10
 
-    lazy val CYCache: List[Bik] = List.tabulate(5)(n => Bik("" + (n + 1), 10))
+    lazy val CYCache: List[Bik] = List.tabulate(noOfElements)(n => Bik("" + (n + 1), bikStatus))
 
     when(service.bikListService.pbikHeaders).thenReturn(Map(HeaderTags.ETAG -> "0", HeaderTags.X_TXID -> "1"))
 
@@ -114,7 +117,7 @@ class RegistrationServiceSpec
           "add",
           nextTaxYearView(_, additive = true, YEAR_RANGE, _, _, _, _, _, EmpRef.empty)
         )
-      status(result)        shouldBe 200
+      status(result)        shouldBe OK
       contentAsString(result) should include(Messages("AddBenefits.Heading"))
       contentAsString(result) should include(Messages("BenefitInKind.label.4"))
     }

--- a/test/services/SessionServiceSpec.scala
+++ b/test/services/SessionServiceSpec.scala
@@ -55,11 +55,12 @@ class SessionServiceSpec
   val TestSessionService: SessionService = new SessionService(mockHttp, mockPbikSessionCache)
 
   val pbikSession: PbikSession = PbikSession(None, None, None, None, None, None, None)
+  val bikStatus                = 30
 
   "The SessionService" should {
 
     "cache a list of registrations" in {
-      val regList = RegistrationList(None, List(RegistrationItem("31", true, true)), None)
+      val regList = RegistrationList(None, List(RegistrationItem("31", active = true, enabled = true)), None)
       when(mockPbikSessionCache.fetchAndGetEntry[PbikSession](any())(any(), any(), any()))
         .thenReturn(Future.successful(None))
       val json    = Json.toJson[PbikSession](pbikSession.copy(registrations = Some(regList)))
@@ -70,7 +71,7 @@ class SessionServiceSpec
     }
 
     "cache a bik to remove" in {
-      val bikRemoved = RegistrationItem("31", true, true)
+      val bikRemoved = RegistrationItem("31", active = true, enabled = true)
       when(mockPbikSessionCache.fetchAndGetEntry[PbikSession](any())(any(), any(), any()))
         .thenReturn(Future.successful(None))
       val json       = Json.toJson[PbikSession](pbikSession.copy(bikRemoved = Some(bikRemoved)))
@@ -114,7 +115,7 @@ class SessionServiceSpec
     }
 
     "cache the current year registered biks" in {
-      val cyRegisteredBiks = List(Bik("31", 30))
+      val cyRegisteredBiks = List(Bik("31", bikStatus))
       when(mockPbikSessionCache.fetchAndGetEntry[PbikSession](any())(any(), any(), any()))
         .thenReturn(Future.successful(None))
       val json             = Json.toJson[PbikSession](pbikSession.copy(cyRegisteredBiks = Some(cyRegisteredBiks)))
@@ -125,7 +126,7 @@ class SessionServiceSpec
     }
 
     "cache the next year registered biks" in {
-      val nyRegisteredBiks = List(Bik("31", 30))
+      val nyRegisteredBiks = List(Bik("31", bikStatus))
       when(mockPbikSessionCache.fetchAndGetEntry[PbikSession](any())(any(), any(), any()))
         .thenReturn(Future.successful(None))
       val json             = Json.toJson[PbikSession](pbikSession.copy(nyRegisteredBiks = Some(nyRegisteredBiks)))
@@ -136,7 +137,8 @@ class SessionServiceSpec
     }
 
     "be able to fetch the pbik session" in {
-      val pbikSession = PbikSession(None, Some(RegistrationItem("31", true, true)), None, None, None, None, None)
+      val pbikSession =
+        PbikSession(None, Some(RegistrationItem("31", active = true, enabled = true)), None, None, None, None, None)
       when(mockPbikSessionCache.fetchAndGetEntry[PbikSession](any())(any(), any(), any()))
         .thenReturn(Future.successful(Some(pbikSession)))
       val result      = await(TestSessionService.fetchPbikSession())(timeout)

--- a/test/support/CYDisabledSetup.scala
+++ b/test/support/CYDisabledSetup.scala
@@ -17,7 +17,7 @@
 package support
 
 import com.google.inject.AbstractModule
-import config.{AppConfig, PbikAppConfig}
+import config.AppConfig
 import connectors.HmrcTierConnector
 import controllers.actions.{AuthAction, NoSessionCheckAction}
 import org.mockito.Mockito.mock

--- a/test/support/MockExclusionListController.scala
+++ b/test/support/MockExclusionListController.scala
@@ -26,6 +26,7 @@ import org.mockito.Mockito.when
 import org.scalatest.concurrent.Futures
 import org.scalatest.time.{Millis, Seconds, Span}
 import play.api.Configuration
+import play.api.http.Status.OK
 import play.api.i18n.MessagesApi
 import play.api.libs.json
 import play.api.libs.json.{JsValue, Json}
@@ -93,8 +94,11 @@ class MockExclusionListController @Inject() (
     )
     with Futures {
 
-  implicit val defaultPatience: PatienceConfig =
-    PatienceConfig(timeout = Span(5, Seconds), interval = Span(500, Millis))
+  implicit val defaultPatience: PatienceConfig = {
+    val fiveSeconds       = 5
+    val fiveHundredMillis = 500
+    PatienceConfig(timeout = Span(fiveSeconds, Seconds), interval = Span(fiveHundredMillis, Millis))
+  }
 
   def logSplunkEvent(dataEvent: DataEvent): Future[AuditResult] =
     Future.successful(AuditResult.Success)
@@ -128,11 +132,11 @@ class MockExclusionListController @Inject() (
   )
     .thenReturn(Future.successful(new FakeResponse()))
 
-  override lazy val exclusionsAllowed = true
+  override lazy val exclusionsAllowed: Boolean = true
 }
 
 class FakeResponse extends HttpResponse {
-  override def status                               = 200
+  override def status: Int                          = OK
   override def allHeaders: Map[String, Seq[String]] = Map()
   override def body: String                         = "empty"
   override val json: JsValue                        = Json.parse("""[

--- a/test/support/StubEiLListService.scala
+++ b/test/support/StubEiLListService.scala
@@ -32,8 +32,19 @@ class StubEiLListService @Inject() (
   uRIInformation: URIInformation
 ) extends EiLListService(pbikAppConfig, tierConnector, uRIInformation) {
 
+  val status                                     = 10
   private lazy val ListOfPeople: List[EiLPerson] = List(
-    EiLPerson("AA111111", "John", Some("Stones"), "Smith", Some("123"), Some("01/01/1980"), Some("male"), Some(10), 0),
+    EiLPerson(
+      "AA111111",
+      "John",
+      Some("Stones"),
+      "Smith",
+      Some("123"),
+      Some("01/01/1980"),
+      Some("male"),
+      Some(status),
+      0
+    ),
     EiLPerson("AB111111", "Adam", None, "Smith", None, Some("01/01/1980"), Some("male"), None, 0),
     EiLPerson(
       "AC111111",
@@ -43,7 +54,7 @@ class StubEiLListService @Inject() (
       Some("123"),
       Some("01/01/1980"),
       Some("male"),
-      Some(10),
+      Some(status),
       0
     ),
     EiLPerson("AD111111", "Peter", Some("James"), "Johnson", None, None, None, None, 0),
@@ -55,7 +66,7 @@ class StubEiLListService @Inject() (
       Some("123"),
       Some("03/02/1978"),
       Some("female"),
-      Some(10),
+      Some(status),
       0
     ),
     EiLPerson(
@@ -66,7 +77,7 @@ class StubEiLListService @Inject() (
       Some("123"),
       Some("01/01/1980"),
       Some("male"),
-      Some(10),
+      Some(status),
       0
     )
   )
@@ -85,7 +96,17 @@ class StubEiLListServiceOneExclusion @Inject() (
 ) extends StubEiLListService(pbikAppConfig, tierConnector, uRIInformation) {
 
   private lazy val ListOfPeople: List[EiLPerson] = List(
-    EiLPerson("AA111111", "John", Some("Stones"), "Smith", Some("123"), Some("01/01/1980"), Some("male"), Some(10), 0),
+    EiLPerson(
+      "AA111111",
+      "John",
+      Some("Stones"),
+      "Smith",
+      Some("123"),
+      Some("01/01/1980"),
+      Some("male"),
+      Some(status),
+      0
+    ),
     EiLPerson("AB111111", "Adam", None, "Smith", None, Some("01/01/1980"), Some("male"), None, 0),
     EiLPerson(
       "AC111111",
@@ -95,7 +116,7 @@ class StubEiLListServiceOneExclusion @Inject() (
       Some("123"),
       Some("01/01/1980"),
       Some("male"),
-      Some(10),
+      Some(status),
       0
     ),
     EiLPerson("AD111111", "Peter", Some("James"), "Johnson", None, None, None, None, 0),
@@ -107,7 +128,7 @@ class StubEiLListServiceOneExclusion @Inject() (
       Some("123"),
       Some("03/02/1978"),
       Some("female"),
-      Some(10),
+      Some(status),
       0
     ),
     EiLPerson(
@@ -118,7 +139,7 @@ class StubEiLListServiceOneExclusion @Inject() (
       Some("123"),
       Some("01/01/1980"),
       Some("male"),
-      Some(10),
+      Some(status),
       0
     )
   )

--- a/test/support/StubNoRegisteredBikListService.scala
+++ b/test/support/StubNoRegisteredBikListService.scala
@@ -36,8 +36,9 @@ class StubNoRegisteredBikListService @Inject() (
   controllersReferenceData: ControllersReferenceData,
   uriInformation: URIInformation
 ) extends BikListService(pbikAppConfig: AppConfig, tierConnector, controllersReferenceData, uriInformation) {
-
+  //scalastyle:off magic.number
   lazy val CYCache: List[Bik] = List.tabulate(21)(n => Bik("" + (n + 1), 10))
+  //scalastyle:on magic.number
 
   when(
     tierConnector.genericGetCall[List[Bik]](any[String], any[String], any[EmpRef], any[Int])(

--- a/test/support/StubNoRegisteredBikListService.scala
+++ b/test/support/StubNoRegisteredBikListService.scala
@@ -20,10 +20,9 @@ import config.AppConfig
 import connectors.HmrcTierConnector
 import javax.inject.Inject
 import models.{Bik, EmpRef}
-import org.mockito.ArgumentMatchers.{any}
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import play.api.libs.json
-import play.api.mvc.Request
 import services.BikListService
 import uk.gov.hmrc.http.HeaderCarrier
 import utils.{ControllersReferenceData, URIInformation}

--- a/test/support/StubbedBikListService.scala
+++ b/test/support/StubbedBikListService.scala
@@ -20,7 +20,6 @@ import config.AppConfig
 import connectors.HmrcTierConnector
 import javax.inject.Inject
 import models.{AuthenticatedRequest, Bik, EmpRef, HeaderTags}
-import play.api.mvc.Request
 import services.BikListService
 import uk.gov.hmrc.http.HeaderCarrier
 import utils.{ControllersReferenceData, URIInformation}

--- a/test/support/StubbedBikListService.scala
+++ b/test/support/StubbedBikListService.scala
@@ -39,7 +39,9 @@ class StubbedBikListService @Inject() (
       uriInformation
     ) {
 
+  //scalastyle:off magic.number
   lazy val CYCache: List[Bik]                        = List.range(3, 32).map(n => Bik("" + n, 10))
+  //scalastyle:on magic.number
   /*(n => new Bik("" + (n + 1), 10))*/
   override lazy val pbikHeaders: Map[String, String] = Map(HeaderTags.ETAG -> "0", HeaderTags.X_TXID -> "1")
 

--- a/test/support/StubbedRegistrationService.scala
+++ b/test/support/StubbedRegistrationService.scala
@@ -62,7 +62,8 @@ class StubbedRegistrationService @Inject() (
     with I18nSupport {
 
   val dateRange: TaxYearRange                          = taxDateUtils.getTaxYearRange()
-  lazy val CYCache: List[Bik]                          = List.tabulate(21)(n => Bik("" + (n + 1), 10))
+  val numberOfElements                                 = 21
+  lazy val CYCache: List[Bik]                          = List.tabulate(numberOfElements)(n => Bik("" + (n + 1), 10))
   lazy val CYRegistrationItems: List[RegistrationItem] =
     List.tabulate(21)(n => RegistrationItem("" + (n + 1), active = true, enabled = true))
   val registeredListOption                             = List.empty[Bik]

--- a/test/utils/BikListUtilsSpec.scala
+++ b/test/utils/BikListUtilsSpec.scala
@@ -22,8 +22,6 @@ import org.scalatestplus.play.PlaySpec
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
 
-import scala.language.reflectiveCalls
-
 class BikListUtilsSpec extends PlaySpec with FakePBIKApplication {
 
   val bikListUtils                                          = app.injector.instanceOf[BikListUtils]

--- a/test/utils/BikListUtilsSpec.scala
+++ b/test/utils/BikListUtilsSpec.scala
@@ -29,163 +29,144 @@ class BikListUtilsSpec extends PlaySpec with FakePBIKApplication {
   val bikListUtils                                          = app.injector.instanceOf[BikListUtils]
   implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest()
 
-  def fixture: Object {
-    val alphaSorted: List[Int]
-    val normaliseResult: List[Int]
-    val biks: List[Bik]
-    val registered: List[Bik]
-    val modifications: List[Bik]
-  } = new {
-    val biks                       = List(
-      Bik("" + 40, 10),
-      Bik("" + 48, 10),
-      Bik("" + 54, 10),
-      Bik("" + 38, 10),
-      Bik("" + 44, 10),
-      Bik("" + 31, 10),
-      Bik("" + 35, 10),
-      Bik("" + 36, 10),
-      Bik("" + 37, 10),
-      Bik("" + 30, 10),
-      Bik("" + 50, 10),
-      Bik("" + 8, 10),
-      Bik("" + 39, 10),
-      Bik("" + 47, 10),
-      Bik("" + 52, 10),
-      Bik("" + 53, 10),
-      Bik("" + 42, 10),
-      Bik("" + 43, 10),
-      Bik("" + 32, 10),
-      Bik("" + 45, 10)
-    )
-    val alphaSorted                = List(39, 40, 31, 42, 43, 52, 37, 38, 44, 45, 47, 32, 48, 30, 50, 8, 53, 36, 35, 54)
-    val registered                 = List(Bik("" + 40, 30), Bik("" + 48, 30), Bik("" + 54, 30), Bik("" + 38, 30), Bik("" + 44, 30))
-    val modifications              =
-      List(Bik("" + 40, 40), Bik("" + 48, 40), Bik("" + 54, 40), Bik("" + 45, 40), Bik("" + 47, 30), Bik("" + 52, 30))
-    val normaliseResult: List[Int] = List(40, 47, 48, 52, 54).sorted
-  }
+  // scalastyle:off magic.number
+  private val alphaSorted = List(39, 40, 31, 42, 43, 52, 37, 38, 44, 45, 47, 32, 48, 30, 50, 8, 53, 36, 35, 54)
+
+  val biks = List(
+    Bik("" + 40, 10),
+    Bik("" + 48, 10),
+    Bik("" + 54, 10),
+    Bik("" + 38, 10),
+    Bik("" + 44, 10),
+    Bik("" + 31, 10),
+    Bik("" + 35, 10),
+    Bik("" + 36, 10),
+    Bik("" + 37, 10),
+    Bik("" + 30, 10),
+    Bik("" + 50, 10),
+    Bik("" + 8, 10),
+    Bik("" + 39, 10),
+    Bik("" + 47, 10),
+    Bik("" + 52, 10),
+    Bik("" + 53, 10),
+    Bik("" + 42, 10),
+    Bik("" + 43, 10),
+    Bik("" + 32, 10),
+    Bik("" + 45, 10)
+  )
+
+  private val registered                 =
+    List(Bik("" + 40, 30), Bik("" + 48, 30), Bik("" + 54, 30), Bik("" + 38, 30), Bik("" + 44, 30))
+  private val modifications              =
+    List(Bik("" + 40, 40), Bik("" + 48, 40), Bik("" + 54, 40), Bik("" + 45, 40), Bik("" + 47, 30), Bik("" + 52, 30))
+  private val normaliseResult: List[Int] = List(40, 47, 48, 52, 54).sorted
+  // scalastyle:on magic.number
 
   "The Biks, when sorted Alphabetically according to labels" should {
-    " result in the correct order" in {
-      val f = fixture
-
-      assert(bikListUtils.sortAlphabeticallyByLabels(f.biks).map(x => x.iabdType.toInt) == f.alphaSorted)
+    "result in the correct order" in {
+      assert(bikListUtils.sortAlphabeticallyByLabels(biks).map(x => x.iabdType.toInt) == alphaSorted)
     }
   }
 
   "The Biks, when sorted Alphabetically according to labels" should {
-    "  be the same size as the original list" in {
-      val f = fixture
-      assert(bikListUtils.sortAlphabeticallyByLabels(f.biks).size == f.biks.size)
+    "be the same size as the original list" in {
+      assert(bikListUtils.sortAlphabeticallyByLabels(biks).size == biks.size)
     }
   }
 
   "The Registration Items, when sorted Alphabetically according to labels" should {
-    " result in the correct order" in {
-      val f = fixture
+    "result in the correct order" in {
       assert(
         bikListUtils
-          .sortRegistrationsAlphabeticallyByLabels(bikListUtils.mergeSelected(f.biks, f.biks))
+          .sortRegistrationsAlphabeticallyByLabels(bikListUtils.mergeSelected(biks, biks))
           .active
-          .map(x => x.id.toInt) == f.alphaSorted
+          .map(x => x.id.toInt) == alphaSorted
       )
     }
   }
 
   "The Registration Items, when sorted Alphabetically according to labels" should {
-    "  be the same size as the original list" in {
-      val f = fixture
+    "be the same size as the original list" in {
       assert(
         bikListUtils
-          .sortRegistrationsAlphabeticallyByLabels(bikListUtils.mergeSelected(f.biks, f.biks))
+          .sortRegistrationsAlphabeticallyByLabels(bikListUtils.mergeSelected(biks, biks))
           .active
-          .size == f.biks.size
+          .size == biks.size
       )
     }
   }
 
   "When normalising additions and removals from a registered list of Biks, the remainder" should {
-    " result in the correct values" in {
-      val f          = fixture
+    "result in the correct values" in {
       val ubinNormed =
-        bikListUtils.normaliseSelectedBenefits(f.registered, f.modifications).map(x => x.iabdType.toInt).sorted
-      assert(ubinNormed == f.normaliseResult)
+        bikListUtils.normaliseSelectedBenefits(registered, modifications).map(x => x.iabdType.toInt).sorted
+      assert(ubinNormed == normaliseResult)
     }
   }
 
   "When normalising additions and removals from a registered list of Biks, the remainder" should {
-    " not contain duplicates" in {
-      val f          = fixture
-      val normalised = bikListUtils.normaliseSelectedBenefits(f.registered, f.modifications)
+    "not contain duplicates" in {
+      val normalised = bikListUtils.normaliseSelectedBenefits(registered, modifications)
       assert(normalised.size == normalised.distinct.size)
     }
   }
 
   "When removing matches is supplied the same list for the initial & checked lists, the remainder" should {
-    " should be empty" in {
-      val f             = fixture
-      val shouldBeEmpty = bikListUtils.removeMatches(f.registered, f.registered)
+    "should be empty" in {
+      val shouldBeEmpty = bikListUtils.removeMatches(registered, registered)
       assert(shouldBeEmpty.active.isEmpty)
     }
   }
 
   "When removing matches the head element, the remainder" should {
-    " should be the tail" in {
-      val f            = fixture
-      val expectedTail = bikListUtils.removeMatches(f.biks, List()).active.tail // manually remove an element
+    "should be the tail" in {
+      val expectedTail = bikListUtils.removeMatches(biks, List()).active.tail // manually remove an element
       val shouldBeTail =
-        bikListUtils.removeMatches(f.biks, List(f.biks.head)).active // check the function does the same
+        bikListUtils.removeMatches(biks, List(biks.head)).active // check the function does the same
       assert(shouldBeTail == expectedTail)
     }
   }
 
   "When merging the same list, the size of the matches" should {
-    " equal the size of the list" in {
-      val f = fixture
-      assert(bikListUtils.mergeSelected(f.biks, f.biks).active.size == f.biks.size)
+    "equal the size of the list" in {
+      assert(bikListUtils.mergeSelected(biks, biks).active.size == biks.size)
     }
   }
 
   "When merging a large list, with a subset of that list, the size of the merge results" should {
-    " equal the size of the superset" in {
-      val f = fixture
-      assert(bikListUtils.mergeSelected(f.biks, f.registered).active.size == f.biks.size)
+    "equal the size of the superset" in {
+      assert(bikListUtils.mergeSelected(biks, registered).active.size == biks.size)
     }
   }
 
   "When merging an original list, with an unconnected list, the size of the merge results" should {
-    " equal the size of the original list as the unconnected elements wont be added" in {
-      val f               = fixture
+    "equal the size of the original list as the unconnected elements wont be added" in {
       val unconnectedList = List(Bik("" + 100000, 40), Bik("" + 100001, 40))
-      assert(bikListUtils.mergeSelected(f.biks, unconnectedList).active.size == f.biks.size)
+      assert(bikListUtils.mergeSelected(biks, unconnectedList).active.size == biks.size)
     }
   }
 
   "When merging selected lists  all of the results" should {
-    " have their active flags set as false" in {
-      val f = fixture
-      assert(bikListUtils.mergeSelected(f.biks, f.biks).active.map(x => x.active).count(identity) == f.biks.size)
+    "have their active flags set as false" in {
+      assert(bikListUtils.mergeSelected(biks, biks).active.map(x => x.active).count(identity) == biks.size)
     }
   }
 
   "When removing two identical lists , the size of the merge results" should {
-    " equal zero" in {
-      val f = fixture
-      assert(bikListUtils.removeMatches(f.biks, f.biks).active.isEmpty)
+    "equal zero" in {
+      assert(bikListUtils.removeMatches(biks, biks).active.isEmpty)
     }
   }
 
   "When removing lists where one list has different elements the size" should {
-    " equal the size of the different elements" in {
-      val f = fixture
-      assert(bikListUtils.removeMatches(f.biks, f.biks).active.isEmpty)
+    "equal the size of the different elements" in {
+      assert(bikListUtils.removeMatches(biks, biks).active.isEmpty)
     }
   }
 
   "When removing lists where both list have unique elements the size" should {
-    " of the result should equal the total number of differences" in {
-      val f = fixture
-      assert(bikListUtils.removeMatches(f.biks, f.registered).active.size == f.biks.size - f.registered.size)
+    "of the result should equal the total number of differences" in {
+      assert(bikListUtils.removeMatches(biks, registered).active.size == biks.size - registered.size)
     }
   }
 

--- a/test/utils/BikListUtilsSpec.scala
+++ b/test/utils/BikListUtilsSpec.scala
@@ -141,7 +141,10 @@ class BikListUtilsSpec extends PlaySpec with FakePBIKApplication {
 
   "When merging an original list, with an unconnected list, the size of the merge results" should {
     "equal the size of the original list as the unconnected elements wont be added" in {
-      val unconnectedList = List(Bik("" + 100000, 40), Bik("" + 100001, 40))
+      val iabdType1       = 100000
+      val iabdType2       = 100001
+      val status          = 40
+      val unconnectedList = List(Bik("" + iabdType1, status), Bik("" + iabdType2, status))
       assert(bikListUtils.mergeSelected(biks, unconnectedList).active.size == biks.size)
     }
   }

--- a/test/utils/ControllersReferenceDataSpec.scala
+++ b/test/utils/ControllersReferenceDataSpec.scala
@@ -125,9 +125,9 @@ class ControllersReferenceDataSpec extends PlaySpec with FakePBIKApplication wit
       implicit val authenticatedRequest: AuthenticatedRequest[AnyContent] =
         AuthenticatedRequest(EmpRef("taxOfficeNumber", "taxOfficeReference"), UserName(Name(None, None)), request)
       val p                                                               = Promise[Result]()
-      p.failure(UpstreamErrorResponse("""{appStatusMessage=10002,}""", 500, 500))
+      p.failure(UpstreamErrorResponse("""{appStatusMessage=10002,}""", INTERNAL_SERVER_ERROR, INTERNAL_SERVER_ERROR))
       val result                                                          = await(mockController.responseErrorHandler(p.future)(authenticatedRequest))
-      result.header.status                             must be(INTERNAL_SERVER_ERROR) // 500
+      result.header.status                             must be(INTERNAL_SERVER_ERROR)
       result.body.asInstanceOf[Strict].data.utf8String must include(messagesApi("ErrorPage.title"))
       result.body.asInstanceOf[Strict].data.utf8String must include(messagesApi("ErrorPage.try.later"))
     }
@@ -140,9 +140,9 @@ class ControllersReferenceDataSpec extends PlaySpec with FakePBIKApplication wit
       implicit val authenticatedRequest: AuthenticatedRequest[AnyContent] =
         AuthenticatedRequest(EmpRef("taxOfficeNumber", "taxOfficeReference"), UserName(Name(None, None)), request)
       val p                                                               = Promise[Result]()
-      p.failure(UpstreamErrorResponse(null, 500, 500))
+      p.failure(UpstreamErrorResponse(null, INTERNAL_SERVER_ERROR, INTERNAL_SERVER_ERROR))
       val result                                                          = await(mockController.responseErrorHandler(p.future)(authenticatedRequest))
-      result.header.status                             must be(INTERNAL_SERVER_ERROR) // 500
+      result.header.status                             must be(INTERNAL_SERVER_ERROR)
       result.body.asInstanceOf[Strict].data.utf8String must include(messagesApi("ErrorPage.title"))
       result.body.asInstanceOf[Strict].data.utf8String must include(messagesApi("ErrorPage.try.later"))
     }
@@ -156,9 +156,9 @@ class ControllersReferenceDataSpec extends PlaySpec with FakePBIKApplication wit
         AuthenticatedRequest(EmpRef("taxOfficeNumber", "taxOfficeReference"), UserName(Name(None, None)), request)
       val p                                                               = Promise[Result]()
       // Note - invalid error message number will not parse
-      p.failure(UpstreamErrorResponse("NO ERROR NUMBER TO PARSE", 500, 500))
+      p.failure(UpstreamErrorResponse("NO ERROR NUMBER TO PARSE", INTERNAL_SERVER_ERROR, INTERNAL_SERVER_ERROR))
       val result                                                          = await(mockController.responseErrorHandler(p.future)(authenticatedRequest))
-      result.header.status                             must be(INTERNAL_SERVER_ERROR) // 500
+      result.header.status                             must be(INTERNAL_SERVER_ERROR)
       result.body.asInstanceOf[Strict].data.utf8String must include(messagesApi("ErrorPage.title"))
       result.body.asInstanceOf[Strict].data.utf8String must include(messagesApi("ErrorPage.try.later"))
     }
@@ -172,9 +172,9 @@ class ControllersReferenceDataSpec extends PlaySpec with FakePBIKApplication wit
         AuthenticatedRequest(EmpRef("taxOfficeNumber", "taxOfficeReference"), UserName(Name(None, None)), request)
       val p                                                               = Promise[Result]()
       // Note - missing comma will prevent message being parsed
-      p.failure(UpstreamErrorResponse("""{appStatusMessage=10002}""", 500, 500))
+      p.failure(UpstreamErrorResponse("""{appStatusMessage=10002}""", INTERNAL_SERVER_ERROR, INTERNAL_SERVER_ERROR))
       val result                                                          = await(mockController.responseErrorHandler(p.future)(authenticatedRequest))
-      result.header.status                             must be(INTERNAL_SERVER_ERROR) // 500
+      result.header.status                             must be(INTERNAL_SERVER_ERROR)
       result.body.asInstanceOf[Strict].data.utf8String must include(messagesApi("ErrorPage.title"))
       result.body.asInstanceOf[Strict].data.utf8String must include(messagesApi("ErrorPage.try.later"))
     }

--- a/test/utils/FormMappingsSpec.scala
+++ b/test/utils/FormMappingsSpec.scala
@@ -133,6 +133,7 @@ class FormMappingsSpec extends PlaySpec with FakePBIKApplication {
 
   "A month value less than 12" should {
     "not be valid in a year" in {
+      //scalastyle:off magic.number
       (-5 to 0)
         .map { i =>
           formMappings.addZeroIfNeeded(i.toString)
@@ -140,12 +141,14 @@ class FormMappingsSpec extends PlaySpec with FakePBIKApplication {
         .foreach { a =>
           assert(!formMappings.isValidDate(("01", a, "2014")))
         }
+      //scalastyle:on magic.number
     }
   }
 
   "The Regex for a year with 4 digits" should {
     "be [0-9][0-9][0-9][0-9]" in {
-      assert(formMappings.generateYearString(4) == "[0-9][0-9][0-9][0-9]")
+      val yearLength = 4
+      assert(formMappings.generateYearString(yearLength) == "[0-9][0-9][0-9][0-9]")
     }
   }
 

--- a/test/utils/SystemPropertiesHelperSpec.scala
+++ b/test/utils/SystemPropertiesHelperSpec.scala
@@ -44,8 +44,9 @@ class SystemPropertiesHelperSpec extends AnyWordSpecLike with Matchers with Opti
 
   "When getting an Int system property which doesnt exist the helper" should {
     "return the default value" in {
-      val s = new StubSystemProperties
-      assert(s.getIntProperty("Intible", 5) == 5)
+      val s            = new StubSystemProperties
+      val defaultValue = 5
+      assert(s.getIntProperty("Intible", defaultValue) == 5)
     }
   }
 

--- a/test/utils/TaxDateUtilsSpec.scala
+++ b/test/utils/TaxDateUtilsSpec.scala
@@ -27,11 +27,16 @@ import java.time.LocalDate
 class TaxDateUtilsSpec extends AnyWordSpecLike with Matchers with OptionValues with FakePBIKApplication {
 
   val taxDateUtils: TaxDateUtils = app.injector.instanceOf[TaxDateUtils]
+  val year2015                   = 2015
+  val year2014                   = 2014
+  val year2013                   = 2013
+  val day7                       = 7
+  val day1                       = 1
 
   "The current tax year" should {
     " be the same as current year, if the current date is before 6th April in the current year" in {
-      val dateBeforeTaxYearButSameYearAsTaxYear = LocalDate.of(2014, APRIL, 1)
-      assert(taxDateUtils.getCurrentTaxYear(dateBeforeTaxYearButSameYearAsTaxYear) == 2013)
+      val dateBeforeTaxYearButSameYearAsTaxYear = LocalDate.of(year2014, APRIL, day1)
+      assert(taxDateUtils.getCurrentTaxYear(dateBeforeTaxYearButSameYearAsTaxYear) == year2013)
     }
   }
 
@@ -43,28 +48,28 @@ class TaxDateUtilsSpec extends AnyWordSpecLike with Matchers with OptionValues w
 
   "The current tax year" should {
     " be current year, if the current date is before 6th April and in the previous year" in {
-      val dateBeforeTaxYearInPreviousYear = LocalDate.of(2013, NOVEMBER, 1)
-      assert(taxDateUtils.getCurrentTaxYear(dateBeforeTaxYearInPreviousYear) == 2013)
+      val dateBeforeTaxYearInPreviousYear = LocalDate.of(year2013, NOVEMBER, 1)
+      assert(taxDateUtils.getCurrentTaxYear(dateBeforeTaxYearInPreviousYear) == year2013)
     }
   }
 
   "The current tax year" should {
     " be current year, if the current date is after 6th April in the current year" in {
-      val dateAfterTaxYear = LocalDate.of(2014, JULY, 1)
-      assert(taxDateUtils.getCurrentTaxYear(dateAfterTaxYear) == 2014)
+      val dateAfterTaxYear = LocalDate.of(year2014, JULY, day1)
+      assert(taxDateUtils.getCurrentTaxYear(dateAfterTaxYear) == year2014)
     }
   }
 
   "The application" should {
     "state the service has NOT launched if the date supplied has the same year as the launch date but is before April 6th" in {
-      val dateAfterTaxYear = LocalDate.of(2015, FEBRUARY, 1)
+      val dateAfterTaxYear = LocalDate.of(year2015, FEBRUARY, day1)
       assert(!taxDateUtils.isServiceLaunched(taxDateUtils.getCurrentTaxYear(dateAfterTaxYear)))
     }
   }
 
   "The application" should {
     "state the service has  launched if the current tax year is after the year of launch" in {
-      val dateAfterTaxYear = LocalDate.of(taxDateUtils.TAX_YEAR_OF_LAUNCH, APRIL, 7)
+      val dateAfterTaxYear = LocalDate.of(taxDateUtils.TAX_YEAR_OF_LAUNCH, APRIL, day7)
       assert(taxDateUtils.getCurrentTaxYear(dateAfterTaxYear) < taxDateUtils.getTaxYearRange().cyminus1)
       assert(taxDateUtils.isServiceLaunched(taxDateUtils.getCurrentTaxYear(dateAfterTaxYear)))
     }
@@ -73,7 +78,7 @@ class TaxDateUtilsSpec extends AnyWordSpecLike with Matchers with OptionValues w
   "The application" should {
     "return the correct range for the current year" in {
 
-      val dateAfterTaxYear = LocalDate.of(taxDateUtils.TAX_YEAR_OF_LAUNCH, APRIL, 7)
+      val dateAfterTaxYear = LocalDate.of(taxDateUtils.TAX_YEAR_OF_LAUNCH, APRIL, day7)
       assert(taxDateUtils.getCurrentTaxYear(dateAfterTaxYear) < taxDateUtils.getTaxYearRange().cyminus1)
       assert(taxDateUtils.isServiceLaunched(taxDateUtils.getCurrentTaxYear(dateAfterTaxYear)))
     }

--- a/test/views/ConfirmNextYearViewSpec.scala
+++ b/test/views/ConfirmNextYearViewSpec.scala
@@ -17,7 +17,7 @@
 package views
 
 import config.{AppConfig, LocalFormPartialRetriever}
-import models.{EmpRef, RegistrationItem, RegistrationList, TaxYearRange}
+import models.{EmpRef, RegistrationItem, RegistrationList}
 import play.api.data.Form
 import play.api.i18n.MessagesApi
 import play.twirl.api.Html

--- a/test/views/ConfirmNextYearViewSpec.scala
+++ b/test/views/ConfirmNextYearViewSpec.scala
@@ -31,8 +31,6 @@ class ConfirmNextYearViewSpec extends PBIKViewSpec {
   val formMappings: FormMappings                             = app.injector.instanceOf[FormMappings]
   val confirmUpdateNextTaxYearView: ConfirmUpdateNextTaxYear = app.injector.instanceOf[ConfirmUpdateNextTaxYear]
 
-  def taxYearRange = TaxYearRange(2018, 2019, 2020)
-
   override def view: Html = viewWithForm(formMappings.objSelectedForm)
 
   implicit val uriInformation: URIInformation                       = app.injector.instanceOf[URIInformation]

--- a/test/views/ExclusionNinoOrNoNinoViewSpec.scala
+++ b/test/views/ExclusionNinoOrNoNinoViewSpec.scala
@@ -31,8 +31,6 @@ class ExclusionNinoOrNoNinoViewSpec extends PBIKViewSpec {
   val formMappings                  = app.injector.instanceOf[FormMappings]
   val exclusionNinoOrNoNinoFormView = app.injector.instanceOf[ExclusionNinoOrNoNinoForm]
 
-  def taxYearRange = TaxYearRange(2018, 2019, 2020)
-
   override def view: Html = viewWithForm()
 
   implicit val taxDateUtils: TaxDateUtils                           = app.injector.instanceOf[TaxDateUtils]

--- a/test/views/ExclusionNinoOrNoNinoViewSpec.scala
+++ b/test/views/ExclusionNinoOrNoNinoViewSpec.scala
@@ -17,7 +17,7 @@
 package views
 
 import config.{AppConfig, LocalFormPartialRetriever, PbikAppConfig}
-import models.{EmpRef, TaxYearRange}
+import models.EmpRef
 import org.jsoup.Jsoup
 import play.api.i18n.MessagesApi
 import play.twirl.api.Html

--- a/test/views/ExclusionOverviewViewSpec.scala
+++ b/test/views/ExclusionOverviewViewSpec.scala
@@ -16,7 +16,7 @@
 
 package views
 
-import models.{EmpRef, TaxYearRange}
+import models.EmpRef
 import play.api.i18n.MessagesApi
 import play.twirl.api.Html
 import utils.FormMappings

--- a/test/views/ExclusionOverviewViewSpec.scala
+++ b/test/views/ExclusionOverviewViewSpec.scala
@@ -30,8 +30,6 @@ class ExclusionOverviewViewSpec extends PBIKViewSpec {
   val formMappings: FormMappings               = app.injector.instanceOf[FormMappings]
   val exclusionOverviewView: ExclusionOverview = app.injector.instanceOf[ExclusionOverview]
 
-  def taxYearRange: TaxYearRange = TaxYearRange(2018, 2019, 2020)
-
   private val iabdType = "31"
 
   override def view: Html =

--- a/test/views/NextYearViewSpec.scala
+++ b/test/views/NextYearViewSpec.scala
@@ -17,7 +17,7 @@
 package views
 
 import config.{AppConfig, LocalFormPartialRetriever}
-import models.{EmpRef, RegistrationList, TaxYearRange}
+import models.{EmpRef, RegistrationList}
 import org.jsoup.Jsoup
 import play.api.data.Form
 import play.api.i18n.MessagesApi

--- a/test/views/NextYearViewSpec.scala
+++ b/test/views/NextYearViewSpec.scala
@@ -32,8 +32,6 @@ class NextYearViewSpec extends PBIKViewSpec {
   val formMappings             = app.injector.instanceOf[FormMappings]
   val nextTaxYearView          = app.injector.instanceOf[NextTaxYear]
 
-  def taxYearRange = TaxYearRange(2018, 2019, 2020)
-
   override def view: Html = viewWithForm(formMappings.objSelectedForm)
 
   implicit val appConfig: AppConfig                                 = app.injector.instanceOf[AppConfig]

--- a/test/views/NinoExclusionSearchViewSpec.scala
+++ b/test/views/NinoExclusionSearchViewSpec.scala
@@ -31,8 +31,6 @@ class NinoExclusionSearchViewSpec extends PBIKViewSpec {
   val formMappings                = app.injector.instanceOf[FormMappings]
   val ninoExclusionSearchFormView = app.injector.instanceOf[NinoExclusionSearchForm]
 
-  def taxYearRange = TaxYearRange(2018, 2019, 2020)
-
   override def view: Html = viewWithForm(formMappings.exclusionSearchFormWithoutNino)
 
   implicit val pbikAppConfig: PbikAppConfig                         = app.injector.instanceOf[PbikAppConfig]

--- a/test/views/NoNinoExclusionSearchViewSpec.scala
+++ b/test/views/NoNinoExclusionSearchViewSpec.scala
@@ -30,8 +30,6 @@ class NoNinoExclusionSearchViewSpec extends PBIKViewSpec {
   val formMappings                  = app.injector.instanceOf[FormMappings]
   val noNinoExclusionSearchFormView = app.injector.instanceOf[NoNinoExclusionSearchForm]
 
-  def taxYearRange = TaxYearRange(2018, 2019, 2020)
-
   override def view: Html = viewWithForm(formMappings.exclusionSearchFormWithoutNino)
 
   def viewWithForm(form: Form[EiLPerson]): Html =

--- a/test/views/SearchResultViewSpec.scala
+++ b/test/views/SearchResultViewSpec.scala
@@ -31,8 +31,6 @@ class SearchResultViewSpec extends PBIKBaseViewSpec {
   val searchResultsView        = app.injector.instanceOf[SearchResults]
   val listOfMatches            = EiLPersonList(List.empty[EiLPerson])
 
-  def taxYearRange = TaxYearRange(2018, 2019, 2020)
-
   def viewWithForm(form: Form[ExclusionNino]): Html =
     searchResultsView(taxYearRange, "cyp1", "30", listOfMatches, form, "", EmpRef("", ""))
 

--- a/test/views/SummaryViewSpec.scala
+++ b/test/views/SummaryViewSpec.scala
@@ -16,7 +16,7 @@
 
 package views
 
-import models.{Bik, EmpRef, TaxYearRange}
+import models.{Bik, EmpRef}
 import org.jsoup.Jsoup
 import play.api.i18n.MessagesApi
 import play.twirl.api.Html
@@ -30,8 +30,6 @@ class SummaryViewSpec extends PBIKViewSpec {
   val messagesApi: MessagesApi            = app.injector.instanceOf[MessagesApi]
   implicit val bikListUtils: BikListUtils = app.injector.instanceOf[BikListUtils]
   val summaryView: Summary                = app.injector.instanceOf[Summary]
-
-  def taxYearRange: TaxYearRange = TaxYearRange(2018, 2019, 2020)
 
   override def view: Html =
     summaryView(cyAllowed = true, taxYearRange, List(), List(Bik("31", 30)), 200, 0, "", EmpRef("", ""))

--- a/test/views/WhatNextAddRemoveViewSpec.scala
+++ b/test/views/WhatNextAddRemoveViewSpec.scala
@@ -16,7 +16,7 @@
 
 package views
 
-import models.{EmpRef, RegistrationItem, RegistrationList, TaxYearRange}
+import models.{EmpRef, RegistrationItem, RegistrationList}
 import play.api.i18n.MessagesApi
 import play.twirl.api.Html
 import utils.FormMappings
@@ -29,8 +29,6 @@ class WhatNextAddRemoveViewSpec extends PBIKViewSpec {
   val formMappings: FormMappings                                               = app.injector.instanceOf[FormMappings]
   val addBenefitConfirmationNextTaxYearView: AddBenefitConfirmationNextTaxYear =
     app.injector.instanceOf[AddBenefitConfirmationNextTaxYear]
-
-  def taxYearRange: TaxYearRange = TaxYearRange(2018, 2019, 2020)
 
   override def view: Html = {
     val regList = RegistrationList(active = List(RegistrationItem("30", true, true)))

--- a/test/views/WhatNextExclusionViewSpec.scala
+++ b/test/views/WhatNextExclusionViewSpec.scala
@@ -17,7 +17,7 @@
 package views
 
 import config.{AppConfig, LocalFormPartialRetriever}
-import models.{EmpRef, TaxYearRange}
+import models.{EmpRef}
 import play.api.i18n.MessagesApi
 import play.twirl.api.Html
 import utils.{FormMappings, URIInformation}
@@ -29,8 +29,6 @@ class WhatNextExclusionViewSpec extends PBIKViewSpec {
   val messagesApi: MessagesApi                 = app.injector.instanceOf[MessagesApi]
   val formMappings: FormMappings               = app.injector.instanceOf[FormMappings]
   val whatNextExclusionView: WhatNextExclusion = app.injector.instanceOf[WhatNextExclusion]
-
-  def taxYearRange = TaxYearRange(2018, 2019, 2020)
 
   implicit val uriInformation: URIInformation                       = app.injector.instanceOf[URIInformation]
   implicit val appConfig: AppConfig                                 = app.injector.instanceOf[AppConfig]

--- a/test/views/helper/JsoupMatchers.scala
+++ b/test/views/helper/JsoupMatchers.scala
@@ -131,7 +131,7 @@ trait JsoupMatchers {
 
   class IdSelectorWithUrlAndTextMatcher(id: String, value: String) extends Matcher[Document] {
     def apply(left: Document): MatchResult = {
-      val element: Element = left.getElementById(id)
+      val element: Element   = left.getElementById(id)
       val valueFound: String = element.attr("value")
 
       MatchResult(
@@ -142,39 +142,44 @@ trait JsoupMatchers {
     }
   }
 
-  def haveHeadingWithText(expectedText: String) = new TagWithTextMatcher(expectedText, "h1")
+  def haveHeadingWithText(expectedText: String): TagWithTextMatcher = new TagWithTextMatcher(expectedText, "h1")
 
-  def haveHeadingH2WithText(expectedText: String) = new TagWithTextMatcher(expectedText, "h2")
+  def haveHeadingH2WithText(expectedText: String): TagWithTextMatcher = new TagWithTextMatcher(expectedText, "h2")
 
-  def haveElementWithIdAndText(expectedText: String, id: String) = new CssSelectorWithTextMatcher(expectedText, s"#$id")
+  def haveElementWithIdAndText(expectedText: String, id: String): CssSelectorWithTextMatcher =
+    new CssSelectorWithTextMatcher(expectedText, s"#$id")
 
-  def haveElementWithId(id: String) = new CssSelector(s"#$id")
+  def haveElementWithId(id: String): CssSelector = new CssSelector(s"#$id")
 
-  def haveBackLink = new CssSelector("a[id=back-link]")
+  def haveBackLink: CssSelector = new CssSelector("a[id=back-link]")
 
-  def haveSubmitButton(expectedText: String) =
+  def haveSubmitButton(expectedText: String): CssSelectorWithAttributeValueMatcher =
     new CssSelectorWithAttributeValueMatcher("value", expectedText, "input[type=submit]")
 
-  def haveFormWithSubmitUrl(url: String) = new CssSelectorWithAttributeValueMatcher("action", url, "form[method=POST]")
+  def haveFormWithSubmitUrl(url: String): CssSelectorWithAttributeValueMatcher =
+    new CssSelectorWithAttributeValueMatcher("action", url, "form[method=POST]")
 
-  def haveInputLabelWithText(id: String, expectedText: String) =
+  def haveInputLabelWithText(id: String, expectedText: String): CssSelectorWithTextMatcher =
     new CssSelectorWithTextMatcher(expectedText, s"label[for=$id]")
 
-  def haveElementAtPathWithText(elementSelector: String, expectedText: String) =
+  def haveElementAtPathWithText(elementSelector: String, expectedText: String): CssSelectorWithTextMatcher =
     new CssSelectorWithTextMatcher(expectedText, elementSelector)
 
-  def haveElementAtPathWithClass(elementSelector: String, className: String) =
+  def haveElementAtPathWithClass(elementSelector: String, className: String): CssSelectorWithClassMatcher =
     new CssSelectorWithClassMatcher(className, elementSelector)
 
-  def haveErrorSummary(expectedText: String) =
+  def haveErrorSummary(expectedText: String): CssSelectorWithTextMatcher =
     new CssSelectorWithTextMatcher(expectedText, ".govuk-list.govuk-error-summary__list")
 
-  def haveErrorNotification(expectedText: String) = new CssSelectorWithTextMatcher(expectedText, ".govuk-error-message")
+  def haveErrorNotification(expectedText: String): CssSelectorWithTextMatcher =
+    new CssSelectorWithTextMatcher(expectedText, ".govuk-error-message")
 
-  def haveClassWithText(expectedText: String, className: String) =
+  def haveClassWithText(expectedText: String, className: String): CssSelectorWithTextMatcher =
     new CssSelectorWithTextMatcher(expectedText, s".$className")
 
-  def haveLinkWithUrlWithID(id: String, expectedURL: String) = new IdSelectorWithUrlMatcher(expectedURL, id)
+  def haveLinkWithUrlWithID(id: String, expectedURL: String): IdSelectorWithUrlMatcher =
+    new IdSelectorWithUrlMatcher(expectedURL, id)
 
-  def haveValueElement(id: String, value: String) = new IdSelectorWithUrlAndTextMatcher(id, value)
+  def haveValueElement(id: String, value: String): IdSelectorWithUrlAndTextMatcher =
+    new IdSelectorWithUrlAndTextMatcher(id, value)
 }

--- a/test/views/helper/PBIKViewSpec.scala
+++ b/test/views/helper/PBIKViewSpec.scala
@@ -16,6 +16,7 @@
 
 package views.helper
 
+import models.TaxYearRange
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.mockito.Mockito.mock
@@ -102,6 +103,12 @@ trait PBIKBaseViewSpec extends PlaySpec with GuiceOneAppPerSuite with I18nSuppor
   implicit val lang: Lang                                   = Lang("en-GB")
   implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest()
   implicit val messages: MessagesApi                        = app.injector.instanceOf[MessagesApi]
+
+  val year2018 = 2018
+  val year2019 = 2019
+  val year2020 = 202
+
+  def taxYearRange: TaxYearRange = TaxYearRange(year2018, year2019, year2020)
 }
 
 trait PBIKViewSpec extends PBIKBaseViewSpec with PBIKViewBehaviours

--- a/test/views/helper/PBIKViewSpec.scala
+++ b/test/views/helper/PBIKViewSpec.scala
@@ -19,16 +19,12 @@ package views.helper
 import models.TaxYearRange
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import org.mockito.Mockito.mock
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.i18n.{I18nSupport, Lang, MessagesApi}
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
 import play.twirl.api.Html
-import uk.gov.hmrc.http.HeaderCarrier
-
-import scala.concurrent.Future
 
 trait PBIKViewBehaviours extends PlaySpec with JsoupMatchers {
 
@@ -106,7 +102,7 @@ trait PBIKBaseViewSpec extends PlaySpec with GuiceOneAppPerSuite with I18nSuppor
 
   val year2018 = 2018
   val year2019 = 2019
-  val year2020 = 202
+  val year2020 = 2020
 
   def taxYearRange: TaxYearRange = TaxYearRange(year2018, year2019, year2020)
 }


### PR DESCRIPTION
# DDCE-3460

The radio buttons are contained in a fieldset but the legend which acts as a group label for the radio buttons has been placed outside of the fieldset. This issue may affect how screen reader users identify the purpose of the radio buttons when navigating out of the context of the page.

## Checklist PR Raiser
- [ ]  I've updated the README if there are functionality changes
- [ ]  I've executed the project script to check Dependencies and update them if they're non-breaking changes
- [ ]  I've executed Scalastyle and fixed any warnings that can be resolved quickly
- [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
- [ ]  I've included appropriate tests with any code I've added (Unit, Integration), and it meets Coverage
- [ ]  I've squashed my commits - including the JIRA issue number in the commit message
- [ ]  I've contacted a BA to create a task if any of these actions would result in a larger piece of work
