### PR TITLE
DDCE-3462: Descriptive link for navigation with screen readers

### DIFF
--- a/app/utils/FormMappings.scala
+++ b/app/utils/FormMappings.scala
@@ -70,6 +70,7 @@ class FormMappings @Inject() (val messagesApi: MessagesApi) extends PayrollBikDe
       date
     }
 
+  //scalastyle:off cyclomatic.complexity
   def isValidDate(dob: (String, String, String)): Boolean =
     try {
       val monthToInt: Int = dob._2.toInt
@@ -102,6 +103,7 @@ class FormMappings @Inject() (val messagesApi: MessagesApi) extends PayrollBikDe
     } catch {
       case ex: NumberFormatException => false
     }
+  //scalastyle:on cyclomatic.complexity
 
   def isDateYearInFuture(dob: (String, String, String)): Boolean = {
     val currentYear = Calendar.getInstance().get(Calendar.YEAR)

--- a/conf/messages
+++ b/conf/messages
@@ -523,7 +523,7 @@ whatNext.remove.p = You will not be taxing {0} through your payroll from 6 April
 whatNext.exclude.heading = Exclusion complete
 whatNext.rescind.heading = Registration complete
 whatNext.exclude.lede = {0} will not have {1} taxed through your payroll from 6 April {2}.
-whatNext.exclude.p1 = From now on, you should report the value of this benefit by sending us a <a class="govuk-link" target = "_blank" rel="noopener noreferrer" href = "https://www.gov.uk/government/publications/paye-end-of-year-expenses-and-benefits-p11d" data-journey-click="link - click:{0}:P11D">P11D</a> for {0}. You should do this at the end of the tax year.
+whatNext.exclude.p1 = From now on, you should report the value of this benefit by sending us a <a class="govuk-link" target = "_blank" rel="noopener noreferrer" href = "https://www.gov.uk/government/publications/paye-end-of-year-expenses-and-benefits-p11d" data-journey-click="link - click:{0}:P11D">P11D employment benefit form - (opens in a new window or tab)</a> for {0}. You should do this at the end of the tax year.
 whatNext.cy1.exclude.p2 = Will no longer have the following benefits and expenses payrolled on {0}
 whatNext.exclude.p3 = Set up your payroll correctly so that the employees don’t have their benefits and expenses taxed in their pay.
 whatNext.exclude.p4 = You’ll need to submit a P11D for those employees you’ve excluded, informing us of the value of the benefits and expenses they receive so we can include it in their tax code.

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -518,7 +518,7 @@ whatNext.remove.p = Ni fyddwch yn trethu {0} drwy’ch cyflogres o 6 Ebrill {1} 
 whatNext.exclude.heading = Eithriad wedi’i gyflawni
 whatNext.rescind.heading = Cofrestriad wedi’i gwblhau
 whatNext.exclude.lede = Ni threthir {1} {0}  drwy’ch cyflogres o 6 Ebrill {2} ymlaen.
-whatNext.exclude.p1 = O hyn ymlaen, dylech roi gwybod am werth y buddiant hwn drwy anfon ffurflen <a class="govuk-link" target = "_blank" rel="noopener noreferrer" href = "https://www.gov.uk/government/publications/paye-end-of-year-expenses-and-benefits-p11d">P11D</a> ar gyfer {0}. Dylech wneud hyn ar ddiwedd y flwyddyn dreth.
+whatNext.exclude.p1 = O hyn ymlaen, dylech roi gwybod am werth y buddiant hwn drwy anfon ffurflen <a class="govuk-link" target = "_blank" rel="noopener noreferrer" href = "https://www.gov.uk/government/publications/paye-end-of-year-expenses-and-benefits-p11d">Ffurflen Budd-dal Cyflogaeth P11D - (yn agor ffenestr neu dab newydd)</a> ar gyfer {0}. Dylech wneud hyn ar ddiwedd y flwyddyn dreth.
 whatNext.cy1.exclude.p2 = Ni fydd y buddiannau a’r treuliau canlynol yn cael eu trethu drwy’r gyflogres bellach ar {0}
 whatNext.exclude.p3 = Dylech drefnu eich cyflogres yn gywir fel nad oes rhaid i’r cyflogeion gael eu buddiannau a’u treuliau wedi’u trethu yn eu cyflog.
 whatNext.exclude.p4 = Bydd yn rhaid i chi gyflwyno ffurflen P11D ar gyfer y cyflogeion hynny yr ydych wedi’u heithrio, gan roi gwybod i ni beth yw gwerth y buddiant neu’r draul y maent yn eu cael fel y gallwn ei gynnwys/chynnwys yn eu cod treth.

--- a/test/controllers/ExclusionListControllerSpec.scala
+++ b/test/controllers/ExclusionListControllerSpec.scala
@@ -847,7 +847,8 @@ class ExclusionListControllerSpec extends PlaySpec with FakePBIKApplication with
       val title                                                         = messagesApi("ServiceMessage.10002")
       val mockExclusionController                                       = app.injector.instanceOf[MockExclusionsDisallowedController]
       implicit val timeout: Timeout                                     = 5 seconds
-      val result                                                        = await(mockExclusionController.removeExclusionsCommit(TEST_IABD).apply(formrequest))(timeout)
+      val result                                                        =
+        await(mockExclusionController.removeExclusionsCommit(TEST_IABD).apply(formrequest))(timeout)
       result.header.status                             must be(FORBIDDEN)
       result.body.asInstanceOf[Strict].data.utf8String must include(title)
     }
@@ -895,7 +896,8 @@ class ExclusionListControllerSpec extends PlaySpec with FakePBIKApplication with
       val title                                                         = messagesApi("ServiceMessage.10002")
       val mockExclusionController                                       = app.injector.instanceOf[MockExclusionsDisallowedController]
       implicit val timeout: Timeout                                     = 5 seconds
-      val result                                                        = await(mockExclusionController.remove(TEST_YEAR_CODE, TEST_IABD, TEST_NINO)(formrequest))(timeout)
+      val result                                                        =
+        await(mockExclusionController.remove(TEST_YEAR_CODE, TEST_IABD, TEST_NINO)(formrequest))(timeout)
       result.header.status                             must be(FORBIDDEN)
       result.body.asInstanceOf[Strict].data.utf8String must include(title)
     }
@@ -1086,7 +1088,8 @@ class ExclusionListControllerSpec extends PlaySpec with FakePBIKApplication with
             )
           )
         )
-      val result                                                = mockExclusionListController.updateExclusions(TEST_YEAR_CODE, TEST_IABD_VALUE).apply(mockrequest)
+      val result                                                =
+        mockExclusionListController.updateExclusions(TEST_YEAR_CODE, TEST_IABD_VALUE).apply(mockrequest)
 
       status(result)               must be(SEE_OTHER)
       redirectLocation(result).get must be(s"/payrollbik/$TEST_YEAR_CODE/$TEST_IABD_VALUE/exclusion-complete")


### PR DESCRIPTION
### DDCE-3462: Descriptive link for navigation with screen readers

Altered the link on the page after completing an exclusion following DAC assessment.
New link shown in attachments in Paragraph 1 under `Next Steps`
Requires Sign Off from Welsh Language

[payrollbik_exclusion-complete_UpdatedWelsh](https://user-images.githubusercontent.com/87376121/201164808-3f024f46-97ee-4b95-b64b-1254e374cf24.png)
[payrollbik_exclusion-complete_UpdatedEnglish](https://user-images.githubusercontent.com/87376121/201164816-be0ae892-a270-409a-bbc5-74e63ae2744a.png)

- [x]  I've executed Scalastyle and fixed any warnings that can be resolved quickly
- [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
