### PR TITLE
DDCE-4251: Remove UR banner incorrectly enabled by templates

### DIFF
--- a/app/views/registration/ConfirmUpdateNextTaxYear.scala.html
+++ b/app/views/registration/ConfirmUpdateNextTaxYear.scala.html
@@ -34,7 +34,7 @@
         empRef: EmpRef
 )(implicit request:Request[_], messages: Messages)
 
-@govukLayoutWrapper(PageTitle(messages("AddBenefits.Confirm.Multiple.Title")), Some(taxYearRange), Some(empRef.toString), empRef = Some(empRef.toString)) {
+@govukLayoutWrapper(PageTitle(messages("AddBenefits.Confirm.Multiple.Title")), empRef = Some(empRef.toString)) {
 
     <h1 id="title" class="govuk-heading-xl">
         <span class="govuk-caption-xl">@messages("Overview.next.heading", s"${taxYearRange.cy}", s"${taxYearRange.cyplus1}")</span>

--- a/app/views/registration/RemoveBenefitConfirmationNextTaxYear.scala.html
+++ b/app/views/registration/RemoveBenefitConfirmationNextTaxYear.scala.html
@@ -34,7 +34,7 @@
         empRef: EmpRef
 )(implicit request:Request[_], messages: Messages)
 
-@govukLayoutWrapper(PageTitle(messages("whatNext.remove.heading")), Some(empRef.toString), showBackLink = false) {
+@govukLayoutWrapper(PageTitle(messages("whatNext.remove.heading")), empRef = Some(empRef.toString), showBackLink = false) {
 
     <section id="print-section">
         <div id="printContainer"></div>

--- a/app/views/registration/RemoveBenefitNextTaxYear.scala.html
+++ b/app/views/registration/RemoveBenefitNextTaxYear.scala.html
@@ -40,7 +40,7 @@
 
 @title = @{ messages("RemoveBenefits.Confirm.Title") }
 
-@govukLayoutWrapper(PageTitle(title, form.hasErrors), Some(taxYearRange), Some(empRef.toString), empRef = Some(empRef.toString)) {
+@govukLayoutWrapper(PageTitle(title, form.hasErrors), empRef = Some(empRef.toString)) {
     @if(form.hasErrors) {
         <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
             <h2 class="govuk-error-summary__title" id="error-summary-title">

--- a/app/views/registration/RemoveBenefitOtherReason.scala.html
+++ b/app/views/registration/RemoveBenefitOtherReason.scala.html
@@ -36,7 +36,7 @@
 
 @benefitLabel = @{ messages("BenefitInKind.label." + uriInformation.iabdValueURLDeMapper(iabdType)) }
 
-@govukLayoutWrapper( PageTitle(messages("RemoveBenefits.other.title"), form.hasErrors), Some("taxYearRange"), Some(empRef.toString), empRef = Some(empRef.toString)) {
+@govukLayoutWrapper( PageTitle(messages("RemoveBenefits.other.title"), form.hasErrors), empRef = Some(empRef.toString)) {
 
     @formWithCSRF(action = controllers.registration.routes.ManageRegistrationController.submitRemoveBenefitOtherReason(iabdType)) {
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -6,19 +6,19 @@ object AppDependencies {
 
   private val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc" %% "play-partials"              % "8.4.0-play-28",
-    "uk.gov.hmrc" %% "tax-year"                   % "3.0.0",
+    "uk.gov.hmrc" %% "tax-year"                   % "3.2.0",
     "uk.gov.hmrc" %% "bootstrap-frontend-play-28" % bootstrapPlayVersion,
-    "uk.gov.hmrc" %% "play-frontend-hmrc"         % "7.3.0-play-28",
+    "uk.gov.hmrc" %% "play-frontend-hmrc"         % "7.7.0-play-28",
     "uk.gov.hmrc" %% "http-caching-client"        % "10.0.0-play-28"
   )
 
   private val test: Seq[ModuleID] = Seq(
     "org.mockito"                  %% "mockito-scala-scalatest" % "1.17.14",
     "uk.gov.hmrc"                  %% "bootstrap-test-play-28"  % bootstrapPlayVersion,
-    "org.jsoup"                     % "jsoup"                   % "1.15.4",
-    "org.scalatest"                %% "scalatest"               % "3.2.15",
-    "com.fasterxml.jackson.module" %% "jackson-module-scala"    % "2.14.2",
-    "com.vladsch.flexmark"          % "flexmark-all"            % "0.64.0"
+    "org.jsoup"                     % "jsoup"                   % "1.16.1",
+    "org.scalatest"                %% "scalatest"               % "3.2.16",
+    "com.fasterxml.jackson.module" %% "jackson-module-scala"    % "2.15.1",
+    "com.vladsch.flexmark"          % "flexmark-all"            % "0.64.8"
   ).map(_ % Test)
 
   def apply(): Seq[ModuleID]      = compile ++ test

--- a/test/utils/MessagesSpec.scala
+++ b/test/utils/MessagesSpec.scala
@@ -32,7 +32,7 @@ class MessagesSpec extends PlaySpec with Logging {
     )
     .build()
 
-  def messagesApi: MessagesApi = injector.instanceOf[MessagesApi]
+  def messagesApi: MessagesApi = injector().instanceOf[MessagesApi]
 
   implicit lazy val messages: Messages = messagesApi.preferred(Seq(Lang("en"), Lang("cy")))
 
@@ -109,7 +109,6 @@ class MessagesSpec extends PlaySpec with Logging {
             s" $key -- English arg seq=$engArgSeq and Welsh arg seq=$welshArgSeq"
         )
       }
-      println(mismatchedArgSequences)
       mismatchedArgSequences.size mustBe 0
     }
   }


### PR DESCRIPTION
### DDCE-4251: Remove UR banner incorrectly enabled by templates

Whilst checking cookie compliancy, discovered that some pages were loading the user research banner and its cookie because `GovukLayoutWrapper` was using the incorrect arguments.
Updated dependencies.
