### PR TITLE
DDCE-6589:PBiK - Implement Session Timeout Dialogue to Keep User Cache Alive

### DIFF
--- a/test/controllers/SignedOutControllerSpec.scala
+++ b/test/controllers/SignedOutControllerSpec.scala
@@ -17,13 +17,22 @@
 package controllers
 
 import base.FakePBIKApplication
+import config.PbikAppConfig
+import models.v1.IabdType
+import models.v1.IabdType.IabdType
+import models.{PbikSession, RegistrationItem, RegistrationList}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{mock, when}
 import play.api.i18n.MessagesApi
 import play.api.mvc._
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
+import repositories.SessionRepository
+import services.SessionService
+import uk.gov.hmrc.mongo.MongoComponent
 import views.html.{IndividualSignedOut, SignedOut}
 
-import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future}
 
 class SignedOutControllerSpec extends FakePBIKApplication {
 
@@ -40,15 +49,55 @@ class SignedOutControllerSpec extends FakePBIKApplication {
     cc.fileMimeTypes,
     ec
   )
+  protected def mongoComponent: MongoComponent                 = injected[MongoComponent]
+  implicit val appConfig: PbikAppConfig                        = injected[PbikAppConfig]
+  private val mockSessionService: SessionService               = mock(classOf[SessionService])
+  private val mockSessionRepository: SessionRepository         = mock(classOf[SessionRepository])
   private val signedOutView: SignedOut                         = injected[SignedOut]
   private val individualSignedOutView: IndividualSignedOut     = injected[IndividualSignedOut]
-  private val signedOutController                              = new SignedOutController(signedOutView, individualSignedOutView, mockMCC, ec)
+  private val signedOutController                              = new SignedOutController(
+    signedOutView,
+    individualSignedOutView,
+    mockMCC,
+    mongoComponent,
+    appConfig,
+    mockSessionService,
+    ec
+  )
   private val fakeRequest: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/")
+  private val iabdType: IabdType                               = IabdType.MedicalInsurance
 
   "SignedOutController" when {
     "keepAlive" must {
-      "return NoContent" in {
-        status(signedOutController.keepAlive().apply(fakeRequest)) mustBe NO_CONTENT
+      "return 200 OK and keep session alive when session exists" in {
+        when(mockSessionService.fetchPbikSession()(any()))
+          .thenReturn(
+            Future.successful(
+              Some(
+                PbikSession(
+                  sessionId,
+                  Some(RegistrationList(active = List(RegistrationItem(iabdType, active = true, enabled = true)))),
+                  None,
+                  None,
+                  None,
+                  None,
+                  None,
+                  None
+                )
+              )
+            )
+          )
+
+        val result = signedOutController.keepAlive()(fakeRequest)
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual "Session kept alive"
+      }
+      "return 401 Unauthorized when session is invalid or expired" in {
+        when(mockSessionService.fetchPbikSession()(any()))
+          .thenReturn(Future.successful(None))
+        val result = signedOutController.keepAlive()(fakeRequest)
+        status(result) mustEqual UNAUTHORIZED
+        contentAsString(result) mustEqual "Invalid or expired session"
       }
     }
 


### PR DESCRIPTION
DDCE-6589:PBiK - Implement Session Timeout Dialogue to Keep User Cache Alive